### PR TITLE
:sparkles: GitHub OAuth Login 추가

### DIFF
--- a/src/main/java/com/market/carrot/login/config/customAuthentication/oauth2/factory/OAuthFactory.java
+++ b/src/main/java/com/market/carrot/login/config/customAuthentication/oauth2/factory/OAuthFactory.java
@@ -2,6 +2,7 @@ package com.market.carrot.login.config.customAuthentication.oauth2.factory;
 
 import com.market.carrot.login.config.customAuthentication.oauth2.providerType.CheckOAuthProvider;
 import com.market.carrot.login.config.customAuthentication.oauth2.providerType.ProviderByFacebook;
+import com.market.carrot.login.config.customAuthentication.oauth2.providerType.ProviderByGitHub;
 import com.market.carrot.login.config.customAuthentication.oauth2.providerType.ProviderByGoogle;
 
 public class OAuthFactory implements ProviderFactory {
@@ -13,6 +14,9 @@ public class OAuthFactory implements ProviderFactory {
 
     } else if (provider.equals("facebook")) {
       return new ProviderByFacebook();
+
+    } else if (provider.equals("github")) {
+      return new ProviderByGitHub();
     }
 
     return null;

--- a/src/main/java/com/market/carrot/login/config/customAuthentication/oauth2/providerType/ProviderByGitHub.java
+++ b/src/main/java/com/market/carrot/login/config/customAuthentication/oauth2/providerType/ProviderByGitHub.java
@@ -1,0 +1,13 @@
+package com.market.carrot.login.config.customAuthentication.oauth2.providerType;
+
+import com.market.carrot.login.config.customAuthentication.oauth2.userinfo.GitHubUserInfo;
+import com.market.carrot.login.config.customAuthentication.oauth2.userinfo.OAuth2UserInfo;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class ProviderByGitHub implements CheckOAuthProvider {
+
+  @Override
+  public OAuth2UserInfo getUserInfo(OAuth2User oAuth2User) {
+    return new GitHubUserInfo(oAuth2User.getAttributes());
+  }
+}

--- a/src/main/java/com/market/carrot/login/config/customAuthentication/oauth2/userinfo/GitHubUserInfo.java
+++ b/src/main/java/com/market/carrot/login/config/customAuthentication/oauth2/userinfo/GitHubUserInfo.java
@@ -1,0 +1,25 @@
+package com.market.carrot.login.config.customAuthentication.oauth2.userinfo;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GitHubUserInfo implements OAuth2UserInfo {
+
+  private final Map<String, Object> attributes;
+
+  @Override
+  public String getProviderId() {
+    return String.valueOf(attributes.get("id"));
+  }
+
+  @Override
+  public String getEmail() {
+    return (String) attributes.get("email");
+  }
+
+  @Override
+  public String getName() {
+    return (String) attributes.get("name");
+  }
+}

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -14,6 +14,7 @@
 </form>
 <a href="/oauth2/authorization/google">구글 로그인</a> <!-- 고정 주소 -->
 <a href="/oauth2/authorization/facebook">페이스북 로그인</a> <!-- 고정 주소 -->
+<a href="/oauth2/authorization/github">깃허브 로그인</a> <!-- 고정 주소 -->
 <a href="/joinForm">회원가입을 아직 하지 않으셨나요 ?</a>
 </body>
 </html>


### PR DESCRIPTION
## Description
1. OAuthFactory
- 분기문에 github 추가

2. ProviderByGitHub
- github 로그인 시 GitHubUserInfo 객체 생성 로직 추가

3. GitHubUserInfo
- GitHub 에서 받아오는 attributes 알맞게 반환할 수 있는 로직 추가

4. LoginForm
- GitHub 로그인 링크 추가