### PR TITLE
Product 수정 사항

### DIFF
--- a/src/main/java/com/market/carrot/login/config/SecurityConfig.java
+++ b/src/main/java/com/market/carrot/login/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
         .antMatchers("/user/**").authenticated()
         .antMatchers("/admin/**").hasRole("ADMIN")
         .antMatchers("/api/user/**").hasAnyRole("USER", "ADMIN")
+        .antMatchers("/api/product/**").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll();
 
     // Form Login 인증 설정

--- a/src/main/java/com/market/carrot/product/controller/ProductApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductApiController.java
@@ -5,16 +5,14 @@ import com.market.carrot.product.dto.response.ProductResponse;
 import com.market.carrot.product.service.ProductService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
-public class ProductController {
+public class ProductApiController {
 
   private final ProductService productService;
 

--- a/src/main/java/com/market/carrot/product/domain/Product.java
+++ b/src/main/java/com/market/carrot/product/domain/Product.java
@@ -1,5 +1,6 @@
 package com.market.carrot.product.domain;
 
+import com.market.carrot.BaseTime;
 import com.market.carrot.category.domain.Category;
 import com.market.carrot.login.domain.Member;
 import java.util.ArrayList;
@@ -23,7 +24,7 @@ import org.hibernate.annotations.DynamicInsert;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Product {
+public class Product extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/market/carrot/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/market/carrot/product/dto/response/ProductResponse.java
@@ -1,5 +1,6 @@
 package com.market.carrot.product.dto.response;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,12 +12,15 @@ public class ProductResponse {
   private final String content;
   private final int price;
   private final int heartCount;
+  private final LocalDateTime createdDate;
+  private final LocalDateTime modifiedDate;
   private final MemberByProductResponse member;
   private final CategoryByProductResponse category;
   private final ImagesResponse images;
 
   @Builder
   public ProductResponse(Long id, String title, String content, int price, int heartCount,
+      LocalDateTime createdDate, LocalDateTime modifiedDate,
       MemberByProductResponse member,
       CategoryByProductResponse category,
       ImagesResponse images) {
@@ -25,6 +29,8 @@ public class ProductResponse {
     this.content = content;
     this.price = price;
     this.heartCount = heartCount;
+    this.createdDate = createdDate;
+    this.modifiedDate = modifiedDate;
     this.member = member;
     this.category = category;
     this.images = images;

--- a/src/main/java/com/market/carrot/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/market/carrot/product/service/ProductServiceImpl.java
@@ -1,6 +1,5 @@
 package com.market.carrot.product.service;
 
-import com.market.carrot.product.domain.Product;
 import com.market.carrot.product.domain.ProductRepository;
 import com.market.carrot.product.dto.response.CategoryByProductResponse;
 import com.market.carrot.product.dto.response.ImagesResponse;
@@ -29,6 +28,8 @@ public class ProductServiceImpl implements ProductService {
             .content(product.getContent())
             .price(product.getPrice())
             .heartCount(product.getHeartCount())
+            .createdDate(product.getCreatedDate())
+            .modifiedDate(product.getModifiedDate())
             .member(MemberByProductResponse.from(product))
             .category(CategoryByProductResponse.from(product))
             .images(ImagesResponse.from(product))


### PR DESCRIPTION
## :sparkles:Description
1. Product
    - BaseTime 추상 클래스 상속받도록 수정
2. ProductApiController
    - @Slf4j 삭제 (일단 안쓰는 거라 ..)
3. ProductResponse
    - 전체 Product 조회 시 Created, ModifiedDate 반환하도록 필드 및 생성자 인자로 추가
4. ProductServiceImpl
    - DB 조회 결과로 받은 List<Product> 타입의 created, modifiedDate 를 List<ProductResponse> 타입으로 반환할 수 있도록 Stream API map() 변환 로직에 추가
5. Product URL 추가로 인가 정책 추가
