### PR TITLE
:sparkles: Product 수정 로직 재구현

### DIFF
--- a/src/main/java/com/market/carrot/product/controller/ProductImageApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductImageApiController.java
@@ -1,0 +1,34 @@
+package com.market.carrot.product.controller;
+
+import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.product.dto.request.UpdateProductImageRequest;
+import com.market.carrot.product.service.ProductImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class ProductImageApiController {
+
+  private final ProductImageService productImageService;
+
+  @PatchMapping("/image/{id}")
+  public GlobalResponseDto updateProductImage(
+      @PathVariable Long id, @RequestBody UpdateProductImageRequest imageRequest) {
+
+    productImageService.updateImage(id, imageRequest);
+
+    return GlobalResponseDto.builder()
+        .code(1)
+        .message("이미지 수정 성공")
+        .build();
+  }
+
+  // TODO 이미지 삭제 구현 예정 (이미지 등록은 상품 등록 시 한번에 하도록 구현했기 때문에 따로 구현하지 않음)
+
+}

--- a/src/main/java/com/market/carrot/product/domain/Product.java
+++ b/src/main/java/com/market/carrot/product/domain/Product.java
@@ -72,12 +72,6 @@ public class Product extends BaseTime {
     this.title = productRequest.getTitle();
     this.content = productRequest.getContent();
     this.price = productRequest.getPrice();
-    this.productImages.clear();
-
-    for (ProductImage productImage : productRequest.getImagesUrl()) {
-      this.productImages.add(productImage);
-      productImage.addProduct(this);
-    }
   }
 
   public void addMember(Member findMember) {

--- a/src/main/java/com/market/carrot/product/domain/ProductImage.java
+++ b/src/main/java/com/market/carrot/product/domain/ProductImage.java
@@ -1,5 +1,6 @@
 package com.market.carrot.product.domain;
 
+import com.market.carrot.product.dto.request.UpdateProductImageRequest;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -25,6 +26,10 @@ public class ProductImage {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id")
   private Product product;
+
+  public void updateProductImage(UpdateProductImageRequest imageRequest) {
+    this.imageUrl = imageRequest.getImageUrl();
+  }
 
   public void addProduct(Product product) {
     this.product = product;

--- a/src/main/java/com/market/carrot/product/domain/ProductImageRepository.java
+++ b/src/main/java/com/market/carrot/product/domain/ProductImageRepository.java
@@ -1,0 +1,7 @@
+package com.market.carrot.product.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+
+}

--- a/src/main/java/com/market/carrot/product/dto/request/UpdateProductImageRequest.java
+++ b/src/main/java/com/market/carrot/product/dto/request/UpdateProductImageRequest.java
@@ -1,0 +1,8 @@
+package com.market.carrot.product.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateProductImageRequest {
+  private String imageUrl;
+}

--- a/src/main/java/com/market/carrot/product/service/ProductImageService.java
+++ b/src/main/java/com/market/carrot/product/service/ProductImageService.java
@@ -1,0 +1,8 @@
+package com.market.carrot.product.service;
+
+import com.market.carrot.product.dto.request.UpdateProductImageRequest;
+
+public interface ProductImageService {
+
+  void updateImage(Long id, UpdateProductImageRequest imageRequest);
+}

--- a/src/main/java/com/market/carrot/product/service/ProductImageServiceImpl.java
+++ b/src/main/java/com/market/carrot/product/service/ProductImageServiceImpl.java
@@ -1,0 +1,26 @@
+package com.market.carrot.product.service;
+
+import com.market.carrot.global.Exception.NotFoundEntityException;
+import com.market.carrot.product.domain.ProductImage;
+import com.market.carrot.product.domain.ProductImageRepository;
+import com.market.carrot.product.dto.request.UpdateProductImageRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ProductImageServiceImpl implements ProductImageService {
+
+  private final ProductImageRepository productImageRepository;
+
+  @Transactional
+  @Override
+  public void updateImage(Long id, UpdateProductImageRequest imageRequest) {
+    ProductImage findProductImage = productImageRepository.findById(id)
+        .orElseThrow(() -> new NotFoundEntityException("존재하지 않는 이미지입니다.", HttpStatus.BAD_REQUEST));
+
+    findProductImage.updateProductImage(imageRequest);
+  }
+}


### PR DESCRIPTION
## Description
1. Product
  - 기존 updateProduct() 메서드에서 ProductImage 관련 로직 삭제

2. ProductImage
  - ProductImageAPI 에서 사용하기 위해 updateProductImage() 메서드 구현

3. ProductImageApiController
  - Product Image 수정 및 삭제와 관련된 Controller 클래스 새로 생성

4. ProductImageService
  - 상품 이미지 수정 시 이미지를 찾고, 클라이언트로부터 받아온 UpdateProductImageRequest DTO 를 통해 이미지를 수정하는 로직 작성

5. UpdateProductImageRequest
  - 이미지 URL 을 받아내는 요청 DTO 클래스 새로 생성