### PR TITLE
Product 비즈니스 로직 관련 Validation 추가

### DIFF
--- a/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
@@ -1,7 +1,11 @@
 package com.market.carrot.global.Exception;
 
 import com.market.carrot.global.GlobalResponseDto;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,12 +24,34 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(UserDuplicatedException.class)
-  public GlobalResponseDto notFoundEntity(UserDuplicatedException userDuplicatedException) {
+  public GlobalResponseDto userDuplicated(UserDuplicatedException userDuplicatedException) {
     log.error("UserDuplicatedException 발생: {}", userDuplicatedException.getMessage());
 
     return GlobalResponseDto.builder()
         .code(-1)
         .message(userDuplicatedException.getMessage())
+        .build();
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public GlobalResponseDto validation(MethodArgumentNotValidException validException) {
+    log.error("ValidException 발생: {}", validException.getMessage());
+    List<ValidationExceptionFieldResponse> responses = new ArrayList<>();
+
+    for (FieldError fieldError : validException.getFieldErrors()) {
+      ValidationExceptionField validationExceptionField = ValidationExceptionField.builder()
+          .fieldName(fieldError.getField())
+          .fieldMessage(fieldError.getDefaultMessage())
+          .build();
+
+      ValidationExceptionFieldResponse response = new ValidationExceptionFieldResponse(validationExceptionField);
+      responses.add(response);
+    }
+
+    return GlobalResponseDto.builder()
+        .code(-1)
+        .message("Valid 관련 예외 발생")
+        .body(responses)
         .build();
   }
 }

--- a/src/main/java/com/market/carrot/global/Exception/ValidationExceptionField.java
+++ b/src/main/java/com/market/carrot/global/Exception/ValidationExceptionField.java
@@ -1,0 +1,17 @@
+package com.market.carrot.global.Exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ValidationExceptionField {
+
+  private final String fieldName;
+  private final String fieldMessage;
+
+  @Builder
+  public ValidationExceptionField(String fieldName, String fieldMessage) {
+    this.fieldName = fieldName;
+    this.fieldMessage = fieldMessage;
+  }
+}

--- a/src/main/java/com/market/carrot/global/Exception/ValidationExceptionFieldResponse.java
+++ b/src/main/java/com/market/carrot/global/Exception/ValidationExceptionFieldResponse.java
@@ -1,0 +1,13 @@
+package com.market.carrot.global.Exception;
+
+import lombok.Getter;
+
+@Getter
+public class ValidationExceptionFieldResponse {
+
+  private final ValidationExceptionField field;
+
+  public ValidationExceptionFieldResponse(ValidationExceptionField field) {
+    this.field = field;
+  }
+}

--- a/src/main/java/com/market/carrot/product/controller/ProductApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductApiController.java
@@ -7,11 +7,11 @@ import com.market.carrot.product.dto.request.UpdateProductRequest;
 import com.market.carrot.product.dto.response.ProductResponse;
 import com.market.carrot.product.service.ProductService;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,7 +48,7 @@ public class ProductApiController {
   }
 
   @PostMapping("/product")
-  public GlobalResponseDto save(@RequestBody CreateProductRequest productRequest,
+  public GlobalResponseDto save(@Valid @RequestBody CreateProductRequest productRequest,
       @AuthenticationPrincipal MemberContext member) {
     productService.save(productRequest, member);
 
@@ -58,9 +58,9 @@ public class ProductApiController {
         .build();
   }
 
-  @PatchMapping("/product/{id}")
+  @PostMapping("/product/{id}")
   public GlobalResponseDto update(@PathVariable Long id,
-      @RequestBody UpdateProductRequest productRequest) {
+      @Valid @RequestBody UpdateProductRequest productRequest) {
     productService.update(id, productRequest);
 
     return GlobalResponseDto.builder()

--- a/src/main/java/com/market/carrot/product/controller/ProductImageApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductImageApiController.java
@@ -5,8 +5,8 @@ import com.market.carrot.product.dto.request.UpdateProductImageRequest;
 import com.market.carrot.product.service.ProductImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +18,7 @@ public class ProductImageApiController {
 
   private final ProductImageService productImageService;
 
-  @PatchMapping("/image/{id}")
+  @PostMapping("/image/{id}")
   public GlobalResponseDto updateProductImage(
       @PathVariable Long id, @RequestBody UpdateProductImageRequest imageRequest) {
 

--- a/src/main/java/com/market/carrot/product/dto/request/CreateProductRequest.java
+++ b/src/main/java/com/market/carrot/product/dto/request/CreateProductRequest.java
@@ -2,15 +2,24 @@ package com.market.carrot.product.dto.request;
 
 import com.market.carrot.product.domain.ProductImage;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class CreateProductRequest {
 
-  // TODO : Validation 필요
+  @NotNull(message = "카테고리를 공백으로 둘 수 없습니다.")
   private Long categoryId;
+
+  @NotBlank(message = "상품 제목을 적어주세요.")
   private String title;
+
+  @NotBlank(message = "상품 내용을 적어주세요.")
   private String content;
+
+  @NotNull(message = "상품 가격을 적어주세요.")
   private int price;
+
   private List<ProductImage> imagesUrl;
 }

--- a/src/main/java/com/market/carrot/product/dto/request/UpdateProductRequest.java
+++ b/src/main/java/com/market/carrot/product/dto/request/UpdateProductRequest.java
@@ -2,15 +2,21 @@ package com.market.carrot.product.dto.request;
 
 import com.market.carrot.product.domain.ProductImage;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class UpdateProductRequest {
 
-  // TODO Validation 필요
-  // 수정 페이지 -> 원래 있던 값들이 다 들어가 있고, 자기가 원하는 값만 수정하도록 수정 페이지가 뜬다고 가정
+  @NotBlank(message = "상품 제목을 적어주세요.")
   private String title;
+
+  @NotBlank(message = "상품 내용을 적어주세요.")
   private String content;
+
+  @NotNull(message = "상품 가격을 적어주세요.")
   private int price;
+
   private List<ProductImage> imagesUrl;
 }


### PR DESCRIPTION
## Description
1. ProductApiController
    - save(), update() 메서드에서 Request DTO 받아오는 부분 @Valid 추가
    - @PatchMapping -> @PostMapping 으로 변경

2. ProductImageApiController
    - @PatchMapping -> @PostMapping 으로 변경

3. CreateProductRequest DTO
    - @Notblank, @NotNull 어노테이션 추가

4. UpdateProductRequest
    - @Notblank, @NotNull 어노테이션 추가

5. ValidationExceptionField
    - @Notblank, @NotNull 어노테이션으로 넘어온 예외 발생 필드 이름과 미리 설정해둔 예외 메세지를 필드 변수로 설정한 객체 생성

6. ValidationExceptionFieldResponse
    - ValidationExceptionField 객체를 필드 변수로 설정한 객체 생성 후 ValidationExceptionFieldResponse 객체로 감싼 뒤 List 에 하나 씩 넣어서 반환하도록 구현

7. GlobalExceptionHandler
    - MethodArgumentNotValidException 예외 발생 시 잡아내는 핸들러 메서드 생성
    - 에러 필드 이름, 메세지를 통해 ValidationExceptionField 객체를 생성하고 ValidationExceptionFieldResponse 로 감싸서 반환하도록 구현