### PR TITLE
:sparkles: 상품 좋아요 구현 및 Security Config 인가 추가

### DIFF
--- a/src/main/java/com/market/carrot/likes/controller/LikesController.java
+++ b/src/main/java/com/market/carrot/likes/controller/LikesController.java
@@ -1,0 +1,30 @@
+package com.market.carrot.likes.controller;
+
+import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.likes.service.LikesService;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class LikesController {
+
+  private final LikesService likesService;
+
+  @PostMapping("/likes/{id}")
+  GlobalResponseDto like(@PathVariable Long id, @AuthenticationPrincipal MemberContext member) {
+
+    likesService.like(id, member);
+
+    return GlobalResponseDto.builder()
+        .code(1)
+        .message(id + "번 제품 좋아요 API 호출 성공")
+        .build();
+  }
+}

--- a/src/main/java/com/market/carrot/likes/domain/Likes.java
+++ b/src/main/java/com/market/carrot/likes/domain/Likes.java
@@ -1,0 +1,44 @@
+package com.market.carrot.likes.domain;
+
+import com.market.carrot.login.domain.Member;
+import com.market.carrot.product.domain.Product;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Likes {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id")
+  private Product product;
+
+  public void addMember(Member member) {
+    this.member = member;
+  }
+
+  public void addProduct(Product product) {
+    this.product = product;
+  }
+
+  public static Likes createLikes() {
+    return new Likes();
+  }
+}

--- a/src/main/java/com/market/carrot/likes/domain/LikesRepository.java
+++ b/src/main/java/com/market/carrot/likes/domain/LikesRepository.java
@@ -1,0 +1,13 @@
+package com.market.carrot.likes.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+  @Query("SELECT l FROM Likes l JOIN FETCH l.member JOIN FETCH l.product where l.member.username = :username and l.product.id = :id")
+  Likes findByUsernameAndProductId(
+      @Param("username") String username,
+      @Param("id") Long id);
+}

--- a/src/main/java/com/market/carrot/likes/service/LikesService.java
+++ b/src/main/java/com/market/carrot/likes/service/LikesService.java
@@ -1,0 +1,8 @@
+package com.market.carrot.likes.service;
+
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+
+public interface LikesService {
+
+  void like(Long id, MemberContext member);
+}

--- a/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
+++ b/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
@@ -1,0 +1,50 @@
+package com.market.carrot.likes.service;
+
+import com.market.carrot.global.Exception.NotFoundEntityException;
+import com.market.carrot.likes.domain.Likes;
+import com.market.carrot.likes.domain.LikesRepository;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.login.domain.Member;
+import com.market.carrot.member.domain.MemberRepository;
+import com.market.carrot.product.domain.Product;
+import com.market.carrot.product.domain.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class LikesServiceImpl implements LikesService {
+
+  private final LikesRepository likesRepository;
+  private final ProductRepository productRepository;
+  private final MemberRepository memberRepository;
+
+  @Transactional
+  @Override
+  public void like(Long id, MemberContext member) {
+    Product findProduct = productRepository.findById(id)
+        .orElseThrow(() -> new NotFoundEntityException("찾을 수 없는 제품입니다.", HttpStatus.BAD_REQUEST));
+
+    Member findMember = memberRepository.findById(member.getMember().getId())
+        .orElseThrow(() -> new NotFoundEntityException("찾을 수 없는 회원입니다.", HttpStatus.BAD_REQUEST));
+
+    Likes findLikes = likesRepository.findByUsernameAndProductId(findMember.getUsername(), id);
+
+    // 자신이 좋아요를 이미 누른 제품인 경우 heartCount 를 하나 줄이고 Entity 를 DB 에서 삭제한다.
+    if (findLikes != null) {
+      likesRepository.delete(findLikes);
+      findProduct.minusHeartCount();
+      return;
+    }
+
+    // 자신이 좋아요를 누르지 않은 제품인 경우 heartCount 를 하나 올려준다.
+    Likes saveLikes = Likes.createLikes();
+    saveLikes.addProduct(findProduct);
+    saveLikes.addMember(findMember);
+
+    likesRepository.save(saveLikes);
+    findProduct.plusHeartCount();
+  }
+}

--- a/src/main/java/com/market/carrot/login/config/SecurityConfig.java
+++ b/src/main/java/com/market/carrot/login/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
         .antMatchers("/admin/**").hasRole("ADMIN")
         .antMatchers("/api/user/**").hasAnyRole("USER", "ADMIN")
         .antMatchers("/api/product/**").hasAnyRole("USER", "ADMIN")
+        .antMatchers("/api/likes/**").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll();
 
     // Form Login 인증 설정

--- a/src/main/java/com/market/carrot/product/domain/Product.java
+++ b/src/main/java/com/market/carrot/product/domain/Product.java
@@ -74,6 +74,14 @@ public class Product extends BaseTime {
     this.price = productRequest.getPrice();
   }
 
+  public void plusHeartCount() {
+    this.heartCount += 1;
+  }
+
+  public void minusHeartCount() {
+    this.heartCount -= 1;
+  }
+
   public void addMember(Member findMember) {
     this.member = findMember;
   }


### PR DESCRIPTION
## Description
1. `Security Config`
    - /api/likes/** 전체 경로에 USER, ADMIN 권한만 접근 가능하도록 설정

2. `Product`
    - plusHeartCount(), minusHeartCount() 메서드 작성
    - 좋아요 하나 늘이거나 줄이는 메서드
    
2. `Likes`
    - MySQL 예약어를 피하기 위해 Likes 로 Entity 명 채택
    - Member, Product 간 1:N 관계
    - 기본 생성자를 활용한 생성자 대용 팩토리 메서드 작성
    
3. `LikesController`
    - 좋아요 API 를 호출하기 위한 Likes Controller 생성
    - void like() 메서드 작성

4. `LikesService`
    - void like() 메서드 호출 시 연관관계에 있는 Product, Member 를 찾고 username, product ID 를 조건절로 한 쿼리를 보내 Likes Entity 가 있는지 찾는다.
    - findLikes 가 null 이 아니라면, 이미 해당 사용자가 좋아요 누른 제품이므로 Likes Entity 를 삭제하고 해당 제품의 좋아요 수를 -1 하는 minusHeartCount() 메서드를 호출한다.
    - null 이라면 해당 사용자가 좋아요 누른 제품이 아니므로 Likes Entity 를 생성해 Product, Member 연관관계를 셋팅하고 Likes Entity 를 저장하고 해당 제품의 좋아요 수를 +1 하는 plusHeartCount() 메서드를 호출한다.

5. `LikesRepository`
    - username (현재 접속한 유저), product ID 를 조건절로 해 Likes Table 을 조회하는 findByUsernameAndProductId() 메서드 작성
