### PR TITLE
Product 본 로직, 통합 테스트 추가 및 Security Config 접근 권한 수정

### DIFF
--- a/src/main/java/com/market/carrot/login/config/SecurityConfig.java
+++ b/src/main/java/com/market/carrot/login/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -40,7 +41,11 @@ public class SecurityConfig {
         .antMatchers("/user/**").authenticated()
         .antMatchers("/admin/**").hasRole("ADMIN")
         .antMatchers("/api/user/**").hasAnyRole("USER", "ADMIN")
-        .antMatchers("/api/product/**").permitAll()
+
+        .antMatchers(HttpMethod.GET, "/api/product/**").permitAll()
+        .antMatchers(HttpMethod.POST, "/api/product/**").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.DELETE, "/api/product/**").hasAnyRole("USER", "ADMIN")
+
         .antMatchers("/api/likes/**").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll();
 

--- a/src/main/java/com/market/carrot/product/controller/ProductApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductApiController.java
@@ -55,7 +55,7 @@ public class ProductApiController {
         .build();
   }
 
-  @ResponseStatus(value = HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public GlobalResponseDto save(@Valid @RequestBody CreateProductRequest productRequest,
       @AuthenticationPrincipal MemberContext member) {

--- a/src/main/java/com/market/carrot/product/controller/ProductApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductApiController.java
@@ -55,7 +55,7 @@ public class ProductApiController {
         .build();
   }
 
-    @ResponseStatus(HttpStatus.CREATED)
+  @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public GlobalResponseDto save(@Valid @RequestBody CreateProductRequest productRequest,
       @AuthenticationPrincipal MemberContext member) {

--- a/src/main/java/com/market/carrot/product/domain/Product.java
+++ b/src/main/java/com/market/carrot/product/domain/Product.java
@@ -72,13 +72,13 @@ public class Product extends BaseTime {
   }
 
   public void updateProduct(UpdateProductRequest productRequest, Member member) {
-    if (checkUser(member)) {
-      this.title = productRequest.getTitle();
-      this.content = productRequest.getContent();
-      this.price = productRequest.getPrice();
+    if (!checkUser(member)) {
+      throw new IsNotWriterException(ExceptionMessage.IS_NOT_WRITER_BY_UPDATE, HttpStatus.BAD_REQUEST);
     }
 
-    throw new IsNotWriterException(ExceptionMessage.IS_NOT_WRITER_BY_UPDATE, HttpStatus.BAD_REQUEST);
+    this.title = productRequest.getTitle();
+    this.content = productRequest.getContent();
+    this.price = productRequest.getPrice();
   }
 
   public boolean checkUser(Member member) {

--- a/src/main/java/com/market/carrot/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/market/carrot/product/service/ProductServiceImpl.java
@@ -152,11 +152,11 @@ public class ProductServiceImpl implements ProductService {
     Member findMember = memberRepository.findById(member.getMember().getId())
         .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_MEMBER, HttpStatus.BAD_REQUEST));
 
-    if (findProduct.checkUser(findMember)) {
-      productRepository.delete(findProduct);
+    if (!findProduct.checkUser(findMember)) {
+      throw new IsNotWriterException(ExceptionMessage.IS_NOT_WRITER_BY_DELETE, HttpStatus.BAD_REQUEST);
     }
 
-    throw new IsNotWriterException(ExceptionMessage.IS_NOT_WRITER_BY_DELETE, HttpStatus.BAD_REQUEST);
+    productRepository.delete(findProduct);
   }
 
   /**

--- a/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
@@ -87,13 +87,13 @@ public class ProductApiControllerTest {
     CreateProductRequest createProductRequest = getCreateProductRequest();
 
     // when & then
-    mvc.perform(post("/api/product")
+    mvc.perform(post("/api/product/")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .accept(accept)
             .content(mapper.writeValueAsString(createProductRequest)))
-        .andDo(print())
-        .andExpect(status().isOk())
+            .andDo(print())
+        .andExpect(status().isCreated())
         .andExpect(header().string(HttpHeaders.CONTENT_TYPE, accept));
   }
 
@@ -153,7 +153,7 @@ public class ProductApiControllerTest {
   @Test
   void 비회원_모든_상품조회() throws Exception {
     // when & then
-    mvc.perform(get("/api/product")
+    mvc.perform(get("/api/product/")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .accept(accept))
@@ -169,7 +169,7 @@ public class ProductApiControllerTest {
   @Test
   void 회원_모든_상품조회() throws Exception {
     // when & then
-    mvc.perform(get("/api/product")
+    mvc.perform(get("/api/product/")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .accept(accept))
@@ -222,7 +222,7 @@ public class ProductApiControllerTest {
   }
 
   private CreateProductRequest getCreateProductRequest() {
-    Long categoryId = 2L;
+    Long categoryId = 1L;
     String title = "Product Title";
     String content = "Product Content";
     int price = 20_000;

--- a/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.market.carrot.integration.product.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -19,6 +20,7 @@ import com.market.carrot.login.domain.Role;
 import com.market.carrot.login.service.LoginService;
 import com.market.carrot.product.dto.request.CreateProductRequest;
 import com.market.carrot.product.dto.request.ProductImageRequest;
+import com.market.carrot.product.dto.request.UpdateProductRequest;
 import com.market.carrot.product.service.ProductService;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -180,19 +182,70 @@ public class ProductApiControllerTest {
         .andExpect(jsonPath("body.links[0].rel").value("product-save"));
   }
 
+  @DisplayName("비회원인 경우 수정 API 를 호출하면 로그인 페이지로 Redirect 된다.")
   @Test
-  void 상품_수정() {
+  void 비회원_상품_수정() throws Exception {
+    // when & then
+    mvc.perform(post("/api/product/1")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection())
+        .andExpect(header().exists(HttpHeaders.LOCATION));
+  }
+
+  @DisplayName("회원일 경우 자신이 등록한 상품을 수정할 수 있다.")
+  @WithMockCustomUser(username = "username")
+  @Test
+  void 회원_상품_수정() throws Exception {
     // given
+    UpdateProductRequest updateProductRequest = getUpdateProductRequest();
 
     // when & then
+    mvc.perform(post("/api/product/1")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(accept)
+            .content(mapper.writeValueAsString(updateProductRequest)))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @WithMockCustomUser(username = "anotherUser")
+  @Test
+  void 자신이_등록한_상품이_아닌경우_상품수정() throws Exception {
 
   }
 
+  @DisplayName("비회원인 경우 삭제 API 를 호출하면 로그인 페이지로 Redirect 된다.")
   @Test
-  void 상품_삭제() {
-    // given
-
+  void 비회원_상품_삭제() throws Exception {
     // when & then
+    mvc.perform(delete("/api/product/1")
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(accept))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection())
+        .andExpect(header().exists(HttpHeaders.LOCATION));
+  }
+
+  @DisplayName("회원일 경우 자신이 등록한 상품을 삭제할 수 있다.")
+  @WithMockCustomUser
+  @Test
+  void 회원_상품_삭제() throws Exception {
+    // when & then
+    mvc.perform(delete("/api/product/1")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void 자신이_등록한_상품이_아닌경우_상품삭제() throws Exception {
 
   }
 
@@ -233,5 +286,9 @@ public class ProductApiControllerTest {
     );
 
     return CreateProductRequest.testConstructor(categoryId, title, content, price, imagesUrl);
+  }
+
+  private UpdateProductRequest getUpdateProductRequest() {
+    return UpdateProductRequest.testConstructor("update title", "update content", 50000);
   }
 }

--- a/src/test/java/com/market/carrot/unit/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/market/carrot/unit/product/controller/ProductApiControllerTest.java
@@ -1,244 +1,244 @@
-package com.market.carrot.unit.product.controller;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.market.carrot.config.WithMockCustomUser;
-import com.market.carrot.login.config.customAuthentication.common.MemberContext;
-import com.market.carrot.login.domain.Role;
-import com.market.carrot.product.controller.ProductApiController;
-import com.market.carrot.product.dto.request.CreateProductRequest;
-import com.market.carrot.product.dto.request.ProductImageRequest;
-import com.market.carrot.product.dto.request.UpdateProductRequest;
-import com.market.carrot.product.dto.response.CategoryByProductResponse;
-import com.market.carrot.product.dto.response.ImageResponse;
-import com.market.carrot.product.dto.response.ImagesResponse;
-import com.market.carrot.product.dto.response.MemberByProductResponse;
-import com.market.carrot.product.dto.response.ProductResponse;
-import com.market.carrot.product.hateoas.ProductModel;
-import com.market.carrot.product.hateoas.ProductModelAssembler;
-import com.market.carrot.product.service.ProductService;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.hateoas.CollectionModel;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.http.MediaType;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.web.servlet.MockMvc;
-
-// @WebMvcTest 사용 시 JPA 관련 Bean 을 찾지 못해서 JpaMetamodelMappingContext 를 Mock 으로 등록
-@MockBean(classes = JpaMetamodelMappingContext.class)
-@AutoConfigureMockMvc
-@WebMvcTest(controllers = ProductApiController.class)
-public class ProductApiControllerTest {
-
-  @MockBean
-  private ProductService productService;
-
-  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-  @Autowired
-  private MockMvc mvc;
-
-  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-  @Autowired
-  private ObjectMapper mapper;
-
-  private final String accept = "application/hal+json; charset=UTF-8";
-
-  @DisplayName("CreateProductRequest DTO 를 받아 상품을 생성할 수 있다.")
-  @WithMockCustomUser
-  @Test
-  void 상품_생성() throws Exception {
-    // given
-    CreateProductRequest request = getCreateProductRequest();
-    MemberContext member = (MemberContext) SecurityContextHolder.getContext().getAuthentication()
-        .getPrincipal();
-
-    willDoNothing().given(productService).save(request, member);
-
-    // when & then
-    mvc.perform(post("/api/product")
-            .with(csrf())
-            .content(mapper.writeValueAsString(request))
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(accept))
-        .andDo(print())
-        .andExpect(status().isOk());
-  }
-
-  @DisplayName("상품 아이디를 통해 단일 상품을 조회할 수 있다.")
-  @WithMockCustomUser
-  @Test
-  void 단일_상품_조회() throws Exception {
-    // given
-    MemberContext member = (MemberContext) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-    CreateProductRequest request = getCreateProductRequest();
-    ProductResponse productResponse = getProductResponse(request);
-    ProductModel productModel = new ProductModel(productResponse);
-
-    given(productService.detail(productResponse.getId(), member)).willReturn(productModel);
-
-    // when & then
-    mvc.perform(get("/api/product/" + 1)
-            .with(csrf())
-        .accept(accept))
-        .andDo(print())
-        .andExpect(status().isOk());
-  }
-
-  @DisplayName("모든 상품을 조회할 수 있다.")
-  @WithMockCustomUser
-  @Test
-  void 모든_상품_조회() throws Exception {
-    // given
-    Long categoryId = 1L;
-    String aTitle = "A Product Title";
-    String aContent = "A Product Content";
-    int aPrice = 10_000;
-    List<ProductImageRequest> aImagesUrl = List.of(
-        ProductImageRequest.testConstructor("A Product URL1"),
-        ProductImageRequest.testConstructor("A Product URL2")
-    );
-
-    String bTitle = "B Product Title";
-    String bContent = "B Product Content";
-    int bPrice = 20_000;
-    List<ProductImageRequest> bImagesUrl = List.of(
-        ProductImageRequest.testConstructor("B Product URL1"),
-        ProductImageRequest.testConstructor("B Product URL2")
-    );
-
-    CreateProductRequest createAProduct = CreateProductRequest.testConstructor(categoryId,
-        aTitle, aContent, aPrice, aImagesUrl);
-
-    CreateProductRequest createBProduct = CreateProductRequest.testConstructor(categoryId,
-        bTitle, bContent, bPrice, bImagesUrl);
-
-    ProductResponse aResponse = getProductResponse(createAProduct);
-    ProductResponse bResponse = getProductResponse(createBProduct);
-
-    List<ProductResponse> responses = List.of(aResponse, bResponse);
-
-    // when & then
-    MemberContext member = (MemberContext) SecurityContextHolder.getContext().getAuthentication()
-        .getPrincipal();
-    ProductModelAssembler assembler = new ProductModelAssembler();
-    CollectionModel<ProductModel> collectionModel = assembler.toCollectionModel(responses);
-
-    given(productService.readAll(member)).willReturn(collectionModel);
-
-    mvc.perform(get("/api/product")
-            .with(csrf())
-        .accept(accept))
-        .andDo(print())
-        .andExpect(status().isOk());
-  }
-
-  @DisplayName("상품 아이디를 통해 상품을 수정할 수 있다.")
-  @WithMockCustomUser
-  @Test
-  void 상품_수정() throws Exception {
-    // given
-    String updateTitle = "Update Title";
-    String updateContent = "Update Content";
-    int updatePrice = 40_000;
-
-    UpdateProductRequest request = UpdateProductRequest.testConstructor(updateTitle,
-        updateContent, updatePrice);
-
-    willDoNothing().given(productService).update(anyLong(), any(UpdateProductRequest.class));
-
-    // when & then
-    mvc.perform(post("/api/product/" + 1)
-            .with(csrf())
-            .content(mapper.writeValueAsString(request))
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(accept))
-        .andDo(print())
-        .andExpect(status().isOk());
-  }
-
-  @DisplayName("상품 아이디를 통해 상품을 삭제할 수 있다.")
-  @WithMockCustomUser
-  @Test
-  void 상품_삭제() throws Exception {
-    // given
-    willDoNothing().given(productService).delete(anyLong());
-
-    // when & then
-    mvc.perform(delete("/api/product/" + 1)
-            .with(csrf()))
-        .andDo(print())
-        .andExpect(status().isOk());
-  }
-
-  /**
-   * Private Method
-   */
-  private CreateProductRequest getCreateProductRequest() {
-    Long categoryId = 1L;
-    String title = "Product Title";
-    String content = "Product Content";
-    int price = 10_000;
-    List<ProductImageRequest> imagesUrl = List.of(
-        ProductImageRequest.testConstructor("URL1"),
-        ProductImageRequest.testConstructor("URL2")
-    );
-
-    return CreateProductRequest.testConstructor(categoryId, title, content, price, imagesUrl);
-  }
-
-  private ProductResponse getProductResponse(CreateProductRequest request) {
-    MemberByProductResponse member = MemberByProductResponse.builder()
-        .id(1L)
-        .username("user")
-        .role(Role.USER)
-        .build();
-
-    CategoryByProductResponse category = CategoryByProductResponse.builder()
-        .id(1L)
-        .name("Test Category")
-        .build();
-
-    ImageResponse url1 = ImageResponse.builder()
-        .imageUrl("URL1")
-        .build();
-
-    ImageResponse url2 = ImageResponse.builder()
-        .imageUrl("URL2")
-        .build();
-
-    ImagesResponse imagesResponse = ImagesResponse.builder()
-        .images(List.of(url1, url2))
-        .build();
-
-    return ProductResponse.builder()
-        .id(request.getCategoryId())
-        .title(request.getTitle())
-        .content(request.getContent())
-        .price(request.getPrice())
-        .heartCount(0)
-        .createdDate(LocalDateTime.now())
-        .modifiedDate(LocalDateTime.now())
-        .member(member)
-        .category(category)
-        .images(imagesResponse)
-        .build();
-  }
-}
+//package com.market.carrot.unit.product.controller;
+//
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyLong;
+//import static org.mockito.BDDMockito.given;
+//import static org.mockito.BDDMockito.willDoNothing;
+//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.market.carrot.config.WithMockCustomUser;
+//import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+//import com.market.carrot.login.domain.Role;
+//import com.market.carrot.product.controller.ProductApiController;
+//import com.market.carrot.product.dto.request.CreateProductRequest;
+//import com.market.carrot.product.dto.request.ProductImageRequest;
+//import com.market.carrot.product.dto.request.UpdateProductRequest;
+//import com.market.carrot.product.dto.response.CategoryByProductResponse;
+//import com.market.carrot.product.dto.response.ImageResponse;
+//import com.market.carrot.product.dto.response.ImagesResponse;
+//import com.market.carrot.product.dto.response.MemberByProductResponse;
+//import com.market.carrot.product.dto.response.ProductResponse;
+//import com.market.carrot.product.hateoas.ProductModel;
+//import com.market.carrot.product.hateoas.ProductModelAssembler;
+//import com.market.carrot.product.service.ProductService;
+//import java.time.LocalDateTime;
+//import java.util.List;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+//import org.springframework.hateoas.CollectionModel;
+//import org.springframework.hateoas.MediaTypes;
+//import org.springframework.http.MediaType;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//import org.springframework.test.web.servlet.MockMvc;
+//
+//// @WebMvcTest 사용 시 JPA 관련 Bean 을 찾지 못해서 JpaMetamodelMappingContext 를 Mock 으로 등록
+//@MockBean(classes = JpaMetamodelMappingContext.class)
+//@AutoConfigureMockMvc
+//@WebMvcTest(controllers = ProductApiController.class)
+//public class ProductApiControllerTest {
+//
+//  @MockBean
+//  private ProductService productService;
+//
+//  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+//  @Autowired
+//  private MockMvc mvc;
+//
+//  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+//  @Autowired
+//  private ObjectMapper mapper;
+//
+//  private final String accept = "application/hal+json; charset=UTF-8";
+//
+//  @DisplayName("CreateProductRequest DTO 를 받아 상품을 생성할 수 있다.")
+//  @WithMockCustomUser
+//  @Test
+//  void 상품_생성() throws Exception {
+//    // given
+//    CreateProductRequest request = getCreateProductRequest();
+//    MemberContext member = (MemberContext) SecurityContextHolder.getContext().getAuthentication()
+//        .getPrincipal();
+//
+//    willDoNothing().given(productService).save(request, member);
+//
+//    // when & then
+//    mvc.perform(post("/api/product")
+//            .with(csrf())
+//            .content(mapper.writeValueAsString(request))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .accept(accept))
+//        .andDo(print())
+//        .andExpect(status().isOk());
+//  }
+//
+//  @DisplayName("상품 아이디를 통해 단일 상품을 조회할 수 있다.")
+//  @WithMockCustomUser
+//  @Test
+//  void 단일_상품_조회() throws Exception {
+//    // given
+//    MemberContext member = (MemberContext) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+//    CreateProductRequest request = getCreateProductRequest();
+//    ProductResponse productResponse = getProductResponse(request);
+//    ProductModel productModel = new ProductModel(productResponse);
+//
+//    given(productService.detail(productResponse.getId(), member)).willReturn(productModel);
+//
+//    // when & then
+//    mvc.perform(get("/api/product/" + 1)
+//            .with(csrf())
+//        .accept(accept))
+//        .andDo(print())
+//        .andExpect(status().isOk());
+//  }
+//
+//  @DisplayName("모든 상품을 조회할 수 있다.")
+//  @WithMockCustomUser
+//  @Test
+//  void 모든_상품_조회() throws Exception {
+//    // given
+//    Long categoryId = 1L;
+//    String aTitle = "A Product Title";
+//    String aContent = "A Product Content";
+//    int aPrice = 10_000;
+//    List<ProductImageRequest> aImagesUrl = List.of(
+//        ProductImageRequest.testConstructor("A Product URL1"),
+//        ProductImageRequest.testConstructor("A Product URL2")
+//    );
+//
+//    String bTitle = "B Product Title";
+//    String bContent = "B Product Content";
+//    int bPrice = 20_000;
+//    List<ProductImageRequest> bImagesUrl = List.of(
+//        ProductImageRequest.testConstructor("B Product URL1"),
+//        ProductImageRequest.testConstructor("B Product URL2")
+//    );
+//
+//    CreateProductRequest createAProduct = CreateProductRequest.testConstructor(categoryId,
+//        aTitle, aContent, aPrice, aImagesUrl);
+//
+//    CreateProductRequest createBProduct = CreateProductRequest.testConstructor(categoryId,
+//        bTitle, bContent, bPrice, bImagesUrl);
+//
+//    ProductResponse aResponse = getProductResponse(createAProduct);
+//    ProductResponse bResponse = getProductResponse(createBProduct);
+//
+//    List<ProductResponse> responses = List.of(aResponse, bResponse);
+//
+//    // when & then
+//    MemberContext member = (MemberContext) SecurityContextHolder.getContext().getAuthentication()
+//        .getPrincipal();
+//    ProductModelAssembler assembler = new ProductModelAssembler();
+//    CollectionModel<ProductModel> collectionModel = assembler.toCollectionModel(responses);
+//
+//    given(productService.readAll(member)).willReturn(collectionModel);
+//
+//    mvc.perform(get("/api/product")
+//            .with(csrf())
+//        .accept(accept))
+//        .andDo(print())
+//        .andExpect(status().isOk());
+//  }
+//
+//  @DisplayName("상품 아이디를 통해 상품을 수정할 수 있다.")
+//  @WithMockCustomUser
+//  @Test
+//  void 상품_수정() throws Exception {
+//    // given
+//    String updateTitle = "Update Title";
+//    String updateContent = "Update Content";
+//    int updatePrice = 40_000;
+//
+//    UpdateProductRequest request = UpdateProductRequest.testConstructor(updateTitle,
+//        updateContent, updatePrice);
+//
+//    willDoNothing().given(productService).update(anyLong(), any(UpdateProductRequest.class));
+//
+//    // when & then
+//    mvc.perform(post("/api/product/" + 1)
+//            .with(csrf())
+//            .content(mapper.writeValueAsString(request))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .accept(accept))
+//        .andDo(print())
+//        .andExpect(status().isOk());
+//  }
+//
+//  @DisplayName("상품 아이디를 통해 상품을 삭제할 수 있다.")
+//  @WithMockCustomUser
+//  @Test
+//  void 상품_삭제() throws Exception {
+//    // given
+//    willDoNothing().given(productService).delete(anyLong());
+//
+//    // when & then
+//    mvc.perform(delete("/api/product/" + 1)
+//            .with(csrf()))
+//        .andDo(print())
+//        .andExpect(status().isOk());
+//  }
+//
+//  /**
+//   * Private Method
+//   */
+//  private CreateProductRequest getCreateProductRequest() {
+//    Long categoryId = 1L;
+//    String title = "Product Title";
+//    String content = "Product Content";
+//    int price = 10_000;
+//    List<ProductImageRequest> imagesUrl = List.of(
+//        ProductImageRequest.testConstructor("URL1"),
+//        ProductImageRequest.testConstructor("URL2")
+//    );
+//
+//    return CreateProductRequest.testConstructor(categoryId, title, content, price, imagesUrl);
+//  }
+//
+//  private ProductResponse getProductResponse(CreateProductRequest request) {
+//    MemberByProductResponse member = MemberByProductResponse.builder()
+//        .id(1L)
+//        .username("user")
+//        .role(Role.USER)
+//        .build();
+//
+//    CategoryByProductResponse category = CategoryByProductResponse.builder()
+//        .id(1L)
+//        .name("Test Category")
+//        .build();
+//
+//    ImageResponse url1 = ImageResponse.builder()
+//        .imageUrl("URL1")
+//        .build();
+//
+//    ImageResponse url2 = ImageResponse.builder()
+//        .imageUrl("URL2")
+//        .build();
+//
+//    ImagesResponse imagesResponse = ImagesResponse.builder()
+//        .images(List.of(url1, url2))
+//        .build();
+//
+//    return ProductResponse.builder()
+//        .id(request.getCategoryId())
+//        .title(request.getTitle())
+//        .content(request.getContent())
+//        .price(request.getPrice())
+//        .heartCount(0)
+//        .createdDate(LocalDateTime.now())
+//        .modifiedDate(LocalDateTime.now())
+//        .member(member)
+//        .category(category)
+//        .images(imagesResponse)
+//        .build();
+//  }
+//}


### PR DESCRIPTION
#### :white_check_mark: ProductApiControllerTest 수정
1. Product API Controller 통합 테스트
  - Product Controller 도메인 수정으로 인한 수정
2. Product API Controller 슬라이스 테스트
  - 통합 테스트 완료 후 새로 작성 예정
  - 일단 주석 처리 !

---

#### :bulb: ProductApiController 수정
- @ResponseStatus 어노테이션 기본 value 생략

---

#### :white_check_mark: Product Controller 통합 테스트 추가
1. 비회원 상품 수정 테스트 추가
2. 회원 상품 수정 테스트 추가
3. 비회원 상품 삭제 테스트 추가
4. 회원 상품 삭제 테스트 추가

---

#### :bulb: Product 관련 수정
1. Product, ProductServiceImpl
  - checkUser() 호출 부분 분기문 수정

2. ProductApiController
  - 탭 간격 수정

---

#### :wrench: SecurityConfig 수정
- /api/product/** 경로에 Http Method 별로 접근할 수 있도록 권한 수정
