### PR TITLE
Product Controller 통합 테스트 추가, 기존 테스트 수정 및 응답 메세지 Enum 클래스 생성 후 적용

### DIFF
--- a/src/main/java/com/market/carrot/global/GlobalResponseMessage.java
+++ b/src/main/java/com/market/carrot/global/GlobalResponseMessage.java
@@ -1,0 +1,31 @@
+package com.market.carrot.global;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalResponseMessage {
+
+  SUCCESS_PRODUCT_LIKE("제품 좋아요 성공"),
+
+  SUCCESS_GET_MEMBER("단건 회원 조회 성공"),
+
+  SUCCESS_DELETE_MEMBER("단건 회원 삭제 성공"),
+
+  SUCCESS_GET_PRODUCTS("모든 상품 조회 성공"),
+
+  SUCCESS_GET_PRODUCT("단건 상품 조회 성공"),
+
+  SUCCESS_POST_INSERT_PRODUCT("상품 등록 성공"),
+
+  SUCCESS_POST_UPDATE_PRODUCT("상품 수정 성공"),
+
+  SUCCESS_DELETE_PRODUCT("상품 삭제 성공"),
+
+  SUCCESS_POST_UPDATE_IMAGE("이미지 수정 성공"),
+
+  SUCCESS_DELETE_IMAGE("이미지 삭제 성공");
+
+  private final String successMessage;
+}

--- a/src/main/java/com/market/carrot/likes/controller/LikesController.java
+++ b/src/main/java/com/market/carrot/likes/controller/LikesController.java
@@ -1,6 +1,7 @@
 package com.market.carrot.likes.controller;
 
 import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.global.GlobalResponseMessage;
 import com.market.carrot.likes.service.LikesService;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class LikesController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.CREATED)
-        .message(id + "번 제품 좋아요 API 호출 성공")
+        .message(GlobalResponseMessage.SUCCESS_PRODUCT_LIKE.getSuccessMessage())
         .build();
   }
 }

--- a/src/main/java/com/market/carrot/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/market/carrot/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package com.market.carrot.member.service;
 import com.market.carrot.global.Exception.ExceptionMessage;
 import com.market.carrot.global.Exception.NotFoundEntityException;
 import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.global.GlobalResponseMessage;
 import com.market.carrot.login.domain.Member;
 import com.market.carrot.member.domain.MemberRepository;
 import com.market.carrot.member.domain.ResponseMemberDetail;
@@ -26,7 +27,7 @@ public class MemberServiceImpl implements MemberService {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("멤버 단건조회 성공")
+        .message(GlobalResponseMessage.SUCCESS_GET_MEMBER.getSuccessMessage())
         .body(ResponseMemberDetail.of(findMember))
         .build();
   }
@@ -42,7 +43,7 @@ public class MemberServiceImpl implements MemberService {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("멤버 탈퇴 성공")
+        .message(GlobalResponseMessage.SUCCESS_DELETE_MEMBER.getSuccessMessage())
         .build();
   }
 }

--- a/src/main/java/com/market/carrot/product/controller/ProductApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductApiController.java
@@ -1,6 +1,7 @@
 package com.market.carrot.product.controller;
 
 import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.global.GlobalResponseMessage;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import com.market.carrot.product.dto.request.CreateProductRequest;
 import com.market.carrot.product.dto.request.UpdateProductRequest;
@@ -36,7 +37,7 @@ public class ProductApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("모든 제품 조회 성공")
+        .message(GlobalResponseMessage.SUCCESS_GET_PRODUCTS.getSuccessMessage())
         .body(productResponses)
         .build();
   }
@@ -50,7 +51,7 @@ public class ProductApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("단일 제품 조회 성공")
+        .message(GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage())
         .body(productResponse)
         .build();
   }
@@ -64,7 +65,7 @@ public class ProductApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.CREATED)
-        .message("상품 등록 성공")
+        .message(GlobalResponseMessage.SUCCESS_POST_INSERT_PRODUCT.getSuccessMessage())
         .build();
   }
 
@@ -78,7 +79,7 @@ public class ProductApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("상품 수정 성공")
+        .message(GlobalResponseMessage.SUCCESS_POST_UPDATE_PRODUCT.getSuccessMessage())
         .build();
   }
 
@@ -91,7 +92,7 @@ public class ProductApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("상품 삭제 성공")
+        .message(GlobalResponseMessage.SUCCESS_DELETE_PRODUCT.getSuccessMessage())
         .build();
   }
 }

--- a/src/main/java/com/market/carrot/product/controller/ProductImageApiController.java
+++ b/src/main/java/com/market/carrot/product/controller/ProductImageApiController.java
@@ -1,6 +1,7 @@
 package com.market.carrot.product.controller;
 
 import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.global.GlobalResponseMessage;
 import com.market.carrot.product.dto.request.UpdateProductImageRequest;
 import com.market.carrot.product.service.ProductImageService;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class ProductImageApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("이미지 수정 성공")
+        .message(GlobalResponseMessage.SUCCESS_POST_UPDATE_IMAGE.getSuccessMessage())
         .build();
   }
 
@@ -44,7 +45,7 @@ public class ProductImageApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.OK)
-        .message("이미지 삭제 성공")
+        .message(GlobalResponseMessage.SUCCESS_DELETE_IMAGE.getSuccessMessage())
         .build();
   }
 }

--- a/src/test/java/com/market/carrot/config/WithMockCustomUser.java
+++ b/src/test/java/com/market/carrot/config/WithMockCustomUser.java
@@ -8,5 +8,7 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
 public @interface WithMockCustomUser {
 
+  long userId() default 1;
+
   String username() default "user";
 }

--- a/src/test/java/com/market/carrot/config/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/market/carrot/config/WithMockCustomUserSecurityContextFactory.java
@@ -21,7 +21,7 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
     roles.add(new SimpleGrantedAuthority("USER"));
 
     Member member = Member.testConstructor(
-        1L, annotation.username(), "password", null, Role.USER
+        annotation.userId(), annotation.username(), "password", null, Role.USER
     );
 
     MemberContext memberContext = new MemberContext(member);


### PR DESCRIPTION
#### :white_check_mark: Product Controller 통합 테스트 추가 및 기존 테스트 수정
1. ProductApiControllerTest
  - 자신이 등록한 상품이 아닌 상품 삭제 테스트 추가
  - 기존 테스트에 code, httpStatus, message 확인 로직 추가
  - 회원이지만 다른 회원인 경우 userId 가 2가 되도록 설정 후 loginService.save() 호출해서 저장되도록 설정

2. WithMockCustomUser, Factory
  - userId 를 설정할 수 있도록 로직 수정

---

#### :bulb: Controller 단 응답 메세지 Enum 적용
- 새로 생성한 GlobalResponseMessage 내 성공 메세지 적용

---

#### :sparkles: 응답 메세지 Enum 클래스화
- 모든 성공 메세지를 관리하도록 Enum 클래스 생성
