### PR TITLE
Member 관련 API 구현 및 필요없는 Custom Exception 제거 및 통합

### DIFF
--- a/src/main/java/com/market/carrot/global/Exception/AnotherMemberException.java
+++ b/src/main/java/com/market/carrot/global/Exception/AnotherMemberException.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public class IsNotWriterException extends RuntimeException {
+public class AnotherMemberException extends RuntimeException {
 
   private final ExceptionMessage errorMessage;
   private final HttpStatus httpStatus;

--- a/src/main/java/com/market/carrot/global/Exception/ExceptionMessage.java
+++ b/src/main/java/com/market/carrot/global/Exception/ExceptionMessage.java
@@ -19,9 +19,11 @@ public enum ExceptionMessage {
 
   USER_DUPLICATED("중복되는 회원 아이디입니다."),
 
-  IS_NOT_WRITER_BY_UPDATE("수정 가능한 회원이 아닙니다."),
+  IS_NOT_MY_PROFILE("조회할 수 있는 프로필이 아닙니다."),
 
-  IS_NOT_WRITER_BY_DELETE("삭제 가능한 회원이 아닙니다.");
+  IS_NOT_MY_PROFILE_BY_DELETE("삭제할 수 있는 프로필이 아닙니다."),
+
+  IS_NOT_WRITER("상품을 작성한 회원이 아닙니다.");
 
   private final String errorMessage;
 }

--- a/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  @ExceptionHandler(IsNotWriterException.class)
-  public GlobalResponseDto isNotWriter(IsNotWriterException isNotWriterException) {
-    log.error("isNotWriterException 발생: {}", isNotWriterException.getMessage());
+  @ExceptionHandler(AnotherMemberException.class)
+  public GlobalResponseDto isNotMyProfile(AnotherMemberException anotherMemberException) {
+    log.error("isNotMyProfileException 발생: {}", anotherMemberException.getMessage());
 
     return GlobalResponseDto.builder()
         .code(-1)
         .httpStatus(HttpStatus.BAD_REQUEST)
-        .message(isNotWriterException.getMessage())
+        .message(anotherMemberException.getMessage())
         .build();
   }
 

--- a/src/main/java/com/market/carrot/global/GlobalResponseMessage.java
+++ b/src/main/java/com/market/carrot/global/GlobalResponseMessage.java
@@ -9,9 +9,9 @@ public enum GlobalResponseMessage {
 
   SUCCESS_PRODUCT_LIKE("제품 좋아요 성공"),
 
-  SUCCESS_GET_MEMBER("단건 회원 조회 성공"),
+  SUCCESS_GET_MEMBER("프로필 조회 성공"),
 
-  SUCCESS_DELETE_MEMBER("단건 회원 삭제 성공"),
+  SUCCESS_DELETE_MEMBER("프로필 삭제 성공"),
 
   SUCCESS_GET_PRODUCTS("모든 상품 조회 성공"),
 

--- a/src/main/java/com/market/carrot/login/config/SecurityConfig.java
+++ b/src/main/java/com/market/carrot/login/config/SecurityConfig.java
@@ -40,7 +40,9 @@ public class SecurityConfig {
     http.authorizeRequests()
         .antMatchers("/user/**").authenticated()
         .antMatchers("/admin/**").hasRole("ADMIN")
-        .antMatchers("/api/user/**").hasAnyRole("USER", "ADMIN")
+
+        .antMatchers(HttpMethod.GET, "/api/user/**").hasAnyRole("USER", "ADMIN")
+        .antMatchers(HttpMethod.DELETE, "/api/user/**").hasAnyRole("USER", "ADMIN")
 
         .antMatchers(HttpMethod.GET, "/api/product/**").permitAll()
         .antMatchers(HttpMethod.POST, "/api/product/**").hasAnyRole("USER", "ADMIN")

--- a/src/main/java/com/market/carrot/login/domain/Member.java
+++ b/src/main/java/com/market/carrot/login/domain/Member.java
@@ -1,6 +1,7 @@
 package com.market.carrot.login.domain;
 
 import com.market.carrot.BaseTime;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -55,5 +56,13 @@ public class Member extends BaseTime implements Serializable {
   public static Member testConstructor(Long id, String username, String password, String email,
       Role role) {
     return new Member(id, username, password, email, role);
+  }
+
+  public boolean checkUser(MemberContext memberContext) {
+    if (this.id.equals(memberContext.getMember().getId())) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/main/java/com/market/carrot/member/controller/MemberApiController.java
+++ b/src/main/java/com/market/carrot/member/controller/MemberApiController.java
@@ -1,10 +1,12 @@
 package com.market.carrot.member.controller;
 
 import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.global.GlobalResponseMessage;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.member.hateoas.MemberModel;
 import com.market.carrot.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -14,29 +16,37 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/")
+@RequestMapping(value = "/api/user/", produces = MediaTypes.HAL_JSON_VALUE)
 @RestController
 public class MemberApiController {
 
   private final MemberService memberService;
 
   @ResponseStatus(HttpStatus.OK)
-  @GetMapping("user/{id}")
-  public GlobalResponseDto detail(@PathVariable Long id,
-      @AuthenticationPrincipal MemberContext memberContext) {
+  @GetMapping("{id}")
+  public GlobalResponseDto readMyProfile(@PathVariable Long id, @AuthenticationPrincipal
+      MemberContext member) {
+    MemberModel memberModel = memberService.readMyProfile(id, member);
 
-    log.info("ROLE_{}", memberContext.getMember().getRole());
-    return memberService.detail(id);
+    return GlobalResponseDto.builder()
+        .code(1)
+        .httpStatus(HttpStatus.OK)
+        .message(GlobalResponseMessage.SUCCESS_GET_MEMBER.getSuccessMessage())
+        .body(memberModel)
+        .build();
   }
 
   @ResponseStatus(HttpStatus.OK)
-  @DeleteMapping("user/{id}")
+  @DeleteMapping("{id}")
   public GlobalResponseDto delete(@PathVariable Long id,
       @AuthenticationPrincipal MemberContext memberContext) {
+    memberService.delete(id, memberContext);
 
-    log.info("ROLE_{}", memberContext.getMember().getRole());
-    return memberService.delete(id);
+    return GlobalResponseDto.builder()
+        .code(1)
+        .httpStatus(HttpStatus.OK)
+        .message(GlobalResponseMessage.SUCCESS_DELETE_MEMBER.getSuccessMessage())
+        .build();
   }
 }

--- a/src/main/java/com/market/carrot/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/market/carrot/member/dto/response/MemberResponse.java
@@ -1,0 +1,18 @@
+package com.market.carrot.member.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+  private final Long id;
+  private final String username;
+  private final String email;
+
+  @Builder
+  public MemberResponse(Long id, String username, String email) {
+    this.id = id;
+    this.username = username;
+    this.email = email;
+  }
+}

--- a/src/main/java/com/market/carrot/member/hateoas/MemberModel.java
+++ b/src/main/java/com/market/carrot/member/hateoas/MemberModel.java
@@ -1,0 +1,17 @@
+package com.market.carrot.member.hateoas;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.market.carrot.member.dto.response.MemberResponse;
+import lombok.Getter;
+import org.springframework.hateoas.EntityModel;
+
+@Getter
+public class MemberModel extends EntityModel<MemberResponse> {
+
+  @JsonUnwrapped
+  private final MemberResponse member;
+
+  public MemberModel(MemberResponse member) {
+    this.member = member;
+  }
+}

--- a/src/main/java/com/market/carrot/member/service/MemberService.java
+++ b/src/main/java/com/market/carrot/member/service/MemberService.java
@@ -1,10 +1,11 @@
 package com.market.carrot.member.service;
 
-import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.member.hateoas.MemberModel;
 
 public interface MemberService {
 
-  GlobalResponseDto detail(Long id);
+  MemberModel readMyProfile(Long id, MemberContext memberContext);
 
-  GlobalResponseDto delete(Long id);
+  void delete(Long id, MemberContext memberContext);
 }

--- a/src/main/java/com/market/carrot/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/market/carrot/member/service/MemberServiceImpl.java
@@ -1,12 +1,16 @@
 package com.market.carrot.member.service;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+import com.market.carrot.global.Exception.AnotherMemberException;
 import com.market.carrot.global.Exception.ExceptionMessage;
 import com.market.carrot.global.Exception.NotFoundEntityException;
-import com.market.carrot.global.GlobalResponseDto;
-import com.market.carrot.global.GlobalResponseMessage;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import com.market.carrot.login.domain.Member;
+import com.market.carrot.member.controller.MemberApiController;
 import com.market.carrot.member.domain.MemberRepository;
-import com.market.carrot.member.domain.ResponseMemberDetail;
+import com.market.carrot.member.dto.response.MemberResponse;
+import com.market.carrot.member.hateoas.MemberModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -20,30 +24,44 @@ public class MemberServiceImpl implements MemberService {
 
   @Transactional(readOnly = true)
   @Override
-  public GlobalResponseDto detail(Long id) {
+  public MemberModel readMyProfile(Long id, MemberContext memberContext) {
     Member findMember = memberRepository.findById(id)
-        .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_MEMBER, HttpStatus.BAD_REQUEST));
+        .orElseThrow(() -> new AnotherMemberException(ExceptionMessage.NOT_FOUND_MEMBER,
+            HttpStatus.BAD_REQUEST));
 
-    return GlobalResponseDto.builder()
-        .code(1)
-        .httpStatus(HttpStatus.OK)
-        .message(GlobalResponseMessage.SUCCESS_GET_MEMBER.getSuccessMessage())
-        .body(ResponseMemberDetail.of(findMember))
+    if (!findMember.checkUser(memberContext)) {
+      throw new AnotherMemberException(ExceptionMessage.IS_NOT_MY_PROFILE,
+          HttpStatus.BAD_REQUEST);
+    }
+
+    MemberResponse memberResponse = MemberResponse.builder()
+        .id(findMember.getId())
+        .username(findMember.getUsername())
+        .email(findMember.getEmail())
         .build();
+
+    MemberModel memberModel = new MemberModel(memberResponse);
+    memberModel.add(linkTo(MemberApiController.class).slash(memberResponse.getId()).withSelfRel());
+    memberModel.add(
+        linkTo(MemberApiController.class).slash(memberResponse.getId()).withRel("member-delete"));
+    memberModel.add(
+        linkTo(MemberApiController.class).slash(memberResponse.getId()).withRel("member-update"));
+
+    return memberModel;
   }
 
   @Transactional
   @Override
-  public GlobalResponseDto delete(Long id) {
+  public void delete(Long id, MemberContext memberContext) {
     Member findMember = memberRepository.findById(id)
-        .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_MEMBER, HttpStatus.BAD_REQUEST));
+        .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_MEMBER,
+            HttpStatus.BAD_REQUEST));
+
+    if (!findMember.checkUser(memberContext)) {
+      throw new AnotherMemberException(ExceptionMessage.IS_NOT_MY_PROFILE_BY_DELETE,
+          HttpStatus.OK);
+    }
 
     memberRepository.delete(findMember);
-
-    return GlobalResponseDto.builder()
-        .code(1)
-        .httpStatus(HttpStatus.OK)
-        .message(GlobalResponseMessage.SUCCESS_DELETE_MEMBER.getSuccessMessage())
-        .build();
   }
 }

--- a/src/main/java/com/market/carrot/product/domain/Product.java
+++ b/src/main/java/com/market/carrot/product/domain/Product.java
@@ -2,8 +2,8 @@ package com.market.carrot.product.domain;
 
 import com.market.carrot.BaseTime;
 import com.market.carrot.category.domain.Category;
+import com.market.carrot.global.Exception.AnotherMemberException;
 import com.market.carrot.global.Exception.ExceptionMessage;
-import com.market.carrot.global.Exception.IsNotWriterException;
 import com.market.carrot.login.domain.Member;
 import com.market.carrot.product.dto.request.UpdateProductRequest;
 import java.util.ArrayList;
@@ -73,7 +73,7 @@ public class Product extends BaseTime {
 
   public void updateProduct(UpdateProductRequest productRequest, Member member) {
     if (!checkUser(member)) {
-      throw new IsNotWriterException(ExceptionMessage.IS_NOT_WRITER_BY_UPDATE, HttpStatus.BAD_REQUEST);
+      throw new AnotherMemberException(ExceptionMessage.IS_NOT_WRITER, HttpStatus.BAD_REQUEST);
     }
 
     this.title = productRequest.getTitle();

--- a/src/main/java/com/market/carrot/product/service/ProductServiceImpl.java
+++ b/src/main/java/com/market/carrot/product/service/ProductServiceImpl.java
@@ -4,8 +4,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import com.market.carrot.category.domain.Category;
 import com.market.carrot.category.domain.CategoryRepository;
+import com.market.carrot.global.Exception.AnotherMemberException;
 import com.market.carrot.global.Exception.ExceptionMessage;
-import com.market.carrot.global.Exception.IsNotWriterException;
 import com.market.carrot.global.Exception.NotFoundEntityException;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import com.market.carrot.login.domain.Member;
@@ -153,7 +153,7 @@ public class ProductServiceImpl implements ProductService {
         .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_MEMBER, HttpStatus.BAD_REQUEST));
 
     if (!findProduct.checkUser(findMember)) {
-      throw new IsNotWriterException(ExceptionMessage.IS_NOT_WRITER_BY_DELETE, HttpStatus.BAD_REQUEST);
+      throw new AnotherMemberException(ExceptionMessage.IS_NOT_WRITER, HttpStatus.BAD_REQUEST);
     }
 
     productRepository.delete(findProduct);

--- a/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
@@ -28,9 +28,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,7 +38,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
-@TestMethodOrder(value = MethodOrderer.OrderAnnotation.class)
 @AutoConfigureMockMvc
 @SpringBootTest
 public class ProductApiControllerTest {
@@ -104,7 +101,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.CREATED.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_POST_INSERT_PRODUCT.getSuccessMessage()));
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_POST_INSERT_PRODUCT.getSuccessMessage()));
   }
 
   @DisplayName("비회원인 경우 단일 상품을 조회했을 때 self link 만 응답에 포함되어야한다.")
@@ -121,7 +119,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage()))
 
         .andExpect(jsonPath("body.links[0].rel").value("self"))
         .andExpect(jsonPath("body.links[0].rel").value("self"))
@@ -143,7 +142,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage()))
 
         .andExpect(jsonPath("body.links[0].rel").exists())
         .andExpect(jsonPath("body.links[0].rel").value("self"));
@@ -163,7 +163,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_GET_PRODUCT.getSuccessMessage()))
 
         .andExpect(jsonPath("body.links[0].rel").exists())
         .andExpect(jsonPath("body.links[0].rel").value("self"))
@@ -187,7 +188,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_GET_PRODUCTS.getSuccessMessage()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_GET_PRODUCTS.getSuccessMessage()))
 
         .andExpect(jsonPath("body.content[0].links[0].rel").exists())
         .andExpect(jsonPath("body.content[0].links[0].rel").value("self"))
@@ -208,7 +210,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_GET_PRODUCTS.getSuccessMessage()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_GET_PRODUCTS.getSuccessMessage()))
 
         .andExpect(jsonPath("body.content[0].links[0].rel").value("self"))
         .andExpect(jsonPath("body.links[0].rel").exists())
@@ -246,7 +249,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_POST_UPDATE_PRODUCT.getSuccessMessage()));
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_POST_UPDATE_PRODUCT.getSuccessMessage()));
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌 경우 수정 호출 시 400 예외가 발생한다.")
@@ -273,7 +277,7 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(-1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.BAD_REQUEST.name()))
-        .andExpect(jsonPath("message").value(ExceptionMessage.IS_NOT_WRITER_BY_UPDATE.getErrorMessage()));
+        .andExpect(jsonPath("message").value(ExceptionMessage.IS_NOT_WRITER.getErrorMessage()));
   }
 
   @DisplayName("비회원인 경우 삭제 API 를 호출하면 로그인 페이지로 Redirect 된다.")
@@ -303,7 +307,8 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
-        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_DELETE_PRODUCT.getSuccessMessage()));
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_DELETE_PRODUCT.getSuccessMessage()));
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌 경우 삭제 호출 시 400 예외가 발생한다.")
@@ -327,7 +332,7 @@ public class ProductApiControllerTest {
 
         .andExpect(jsonPath("code").value(-1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.BAD_REQUEST.name()))
-        .andExpect(jsonPath("message").value(ExceptionMessage.IS_NOT_WRITER_BY_DELETE.getErrorMessage()));
+        .andExpect(jsonPath("message").value(ExceptionMessage.IS_NOT_WRITER.getErrorMessage()));
   }
 
   /**

--- a/src/test/java/com/market/carrot/integration/product/member/MemberApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/product/member/MemberApiControllerTest.java
@@ -1,0 +1,139 @@
+package com.market.carrot.integration.product.member;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.market.carrot.config.DatabaseCleanup;
+import com.market.carrot.config.WithMockCustomUser;
+import com.market.carrot.global.Exception.ExceptionMessage;
+import com.market.carrot.global.GlobalResponseMessage;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.login.domain.Member;
+import com.market.carrot.login.domain.Role;
+import com.market.carrot.login.service.LoginService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class MemberApiControllerTest {
+
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+  @Autowired
+  private MockMvc mvc;
+
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+  @Autowired
+  private ObjectMapper mapper;
+
+  @Autowired
+  private DatabaseCleanup databaseCleanup;
+
+  @Autowired
+  private LoginService loginService;
+
+  @BeforeEach
+  void saveMember() {
+    Member createMember = Member.testConstructor(
+        1L, "username", "password", "email", Role.USER);
+    MemberContext member = new MemberContext(createMember);
+
+    loginService.save(member.getMember());
+  }
+
+  @AfterEach
+  void clearDB() {
+    databaseCleanup.execute();
+  }
+
+  private final String accept = "application/hal+json;charset=UTF-8";
+
+  @DisplayName("비회원인경우 어떤 프로필도 조회하지 못하고 /loginForm 으로 302 Redirect 된다.")
+  @Test
+  void 비회원_프로필_조회() throws Exception {
+    // when & then
+    mvc.perform(get("/api/user/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection())
+        .andExpect(header().exists(HttpHeaders.LOCATION));
+  }
+
+  @DisplayName("회원이면서 자신의 프로필을 조회한다면 self, update, delete link 모두 응답에 포함되어야한다.")
+  @WithMockCustomUser(userId = 1, username = "username")
+  @Test
+  void 회원_내_프로필_조회() throws Exception {
+    // when & then
+    mvc.perform(get("/api/user/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isOk())
+
+        .andExpect(jsonPath("code").value(1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_GET_MEMBER.getSuccessMessage()));
+  }
+
+  @DisplayName("회원이지만 자신의 프로필을 조회하는게 아닌 경우 조회 호출 시 400 예외가 발생한다.")
+  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @Test
+  void 회원_다른_회원의_프로필_조회() throws Exception {
+    // when & then
+    mvc.perform(get("/api/user/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+
+  @DisplayName("회원이라면 자신의 프로필을 삭제할 수 있다.")
+  @WithMockCustomUser(userId = 1, username = "username")
+  @Test
+  void 회원_내_프로필_삭제() throws Exception {
+    // when & then
+    mvc.perform(delete("/api/user/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isOk())
+
+        .andExpect(jsonPath("code").value(1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.OK.name()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_DELETE_MEMBER.getSuccessMessage()));
+  }
+
+  @DisplayName("회원이지만 자신의 프로필을 삭제하는게 아닌 경우 삭제 호출 시 400 예외가 발생한다.")
+  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @Test
+  void 회원_다른_회원_프로필_삭제() throws Exception {
+    // when & then
+    mvc.perform(delete("/api/user/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+
+        .andExpect(jsonPath("code").value(-1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.BAD_REQUEST.name()))
+        .andExpect(jsonPath("message").value(
+            ExceptionMessage.IS_NOT_MY_PROFILE_BY_DELETE.getErrorMessage()));
+  }
+}


### PR DESCRIPTION
#### :bulb: Product 관련 예외 발생 클래스 및 메세지 변경
1. Product
    - 분기문 내 Exception 클래스 변경 (IsNotWriter -> AnotherMember)

2. ProductApiControllerTest
    - 구글 스타일 적용

3. ProductService
    - IsNotWriter -> AnotherMember

---

#### :bulb: Member API Controller 수정
1. MemberApiController
    - 내 프로필 조회 구현 완료
    - 내 프로필 삭제 구현 완료

2. MemberService
    - 내 프로필 조회 시 Hateoas 적용 완료
    - 내 프로필 삭제 수정 완료

3. MemberResponse
    - 내 프로필 조회 시 사용되는 Response DTO 생성

4. MemberModel
    - Spring Hateoas 적용을 위해 생성
    - MemberResponse 를 감싸서 클라이언트로 응답

5. Member
    - 현재 로그인한 회원과 찾은 findMember 를 비교하기 위한 메서드 추가

---

#### :wrench: Security Config 수정
- /api/user/** 경로 Http Method 에 따라 접근 권한 수정

---

#### :bulb: ExceptionHandler 추가
- AnotherMemberException 핸들러 추가
- isNotWriterException 삭제 후 AnotherMemberException 클래스와 통합해서 사용

---

#### :sparkles: 커스텀 예외 클래스 생성
- 현재 로그인한 회원과 비교를 위한 로직에서 사용되는 AnotherMemberException 예외 클래스 생성

---

#### :bulb: Enum 클래스 내 예외, 성공 메세지 수정
- ExceptionMessage, GlobalResponseMessage 수정 발생
