### PR TITLE
Likes 관련 수정사항 반영

### DIFF
--- a/src/main/java/com/market/carrot/likes/controller/LikesApiController.java
+++ b/src/main/java/com/market/carrot/likes/controller/LikesApiController.java
@@ -5,6 +5,7 @@ import com.market.carrot.global.GlobalResponseMessage;
 import com.market.carrot.likes.service.LikesService;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,14 +15,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/")
+@RequestMapping(value = "/api/likes/", produces = MediaTypes.HAL_JSON_VALUE)
 @RestController
-public class LikesController {
+public class LikesApiController {
 
   private final LikesService likesService;
 
   @ResponseStatus(HttpStatus.CREATED)
-  @PostMapping("likes/{id}")
+  @PostMapping("{id}")
   GlobalResponseDto like(@PathVariable Long id, @AuthenticationPrincipal MemberContext memberContext) {
 
     likesService.like(id, memberContext);

--- a/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
+++ b/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
@@ -28,10 +28,7 @@ public class LikesServiceImpl implements LikesService {
     Product findProduct = productRepository.findById(id)
         .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_PRODUCT, HttpStatus.BAD_REQUEST));
 
-    Member findMember = memberRepository.findById(memberContext.getMember().getId())
-        .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_MEMBER, HttpStatus.BAD_REQUEST));
-
-    Likes findLikes = likesRepository.findByUsernameAndProductId(findMember.getUsername(), id);
+    Likes findLikes = likesRepository.findByUsernameAndProductId(memberContext.getUsername(), id);
 
     // 자신이 좋아요를 이미 누른 제품인 경우 heartCount 를 하나 줄이고 Entity 를 DB 에서 삭제한다.
     if (findLikes != null) {
@@ -43,7 +40,7 @@ public class LikesServiceImpl implements LikesService {
     // 자신이 좋아요를 누르지 않은 제품인 경우 heartCount 를 하나 올려준다.
     Likes saveLikes = Likes.createLikes();
     saveLikes.addProduct(findProduct);
-    saveLikes.addMember(findMember);
+    saveLikes.addMember(memberContext.getMember());
 
     likesRepository.save(saveLikes);
     findProduct.plusHeartCount();

--- a/src/main/java/com/market/carrot/login/config/SecurityConfig.java
+++ b/src/main/java/com/market/carrot/login/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.POST, "/api/image/**").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.DELETE, "/api/image/**").hasAnyRole("USER", "ADMIN")
 
+        .antMatchers(HttpMethod.POST, "/api/likes/**").hasAnyRole("USER", "ADMIN")
+
         .antMatchers("/api/likes/**").hasAnyRole("USER", "ADMIN")
         .anyRequest().permitAll();
 

--- a/src/test/java/com/market/carrot/integration/like/controller/LikesApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/like/controller/LikesApiControllerTest.java
@@ -1,0 +1,172 @@
+package com.market.carrot.integration.like.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.market.carrot.category.domain.dto.CreateCategoryRequest;
+import com.market.carrot.category.service.CategoryService;
+import com.market.carrot.config.DatabaseCleanup;
+import com.market.carrot.config.WithMockCustomUser;
+import com.market.carrot.global.Exception.ExceptionMessage;
+import com.market.carrot.global.GlobalResponseMessage;
+import com.market.carrot.likes.service.LikesService;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.login.domain.Member;
+import com.market.carrot.login.domain.Role;
+import com.market.carrot.login.service.LoginService;
+import com.market.carrot.product.dto.request.CreateProductRequest;
+import com.market.carrot.product.dto.request.ProductImageRequest;
+import com.market.carrot.product.service.ProductService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class LikesApiControllerTest {
+
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+  @Autowired
+  private MockMvc mvc;
+
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+  @Autowired
+  private ObjectMapper mapper;
+
+  @Autowired
+  private DatabaseCleanup databaseCleanup;
+
+  @Autowired
+  private LoginService loginService;
+
+  @Autowired
+  private ProductService productService;
+
+  @Autowired
+  private CategoryService categoryService;
+
+  @Autowired
+  private LikesService likesService;
+
+  private final String accept = "application/hal+json;charset=UTF-8";
+
+  @BeforeEach
+  void saveProduct() {
+    Member createMember = Member.testConstructor(
+        1L, "username", "password", "email", Role.USER);
+    MemberContext memberContext = new MemberContext(createMember);
+
+    CreateProductRequest productRequest = getInitProduct();
+    CreateCategoryRequest categoryRequest = getInitCategory();
+
+    loginService.save(memberContext.getMember());
+    categoryService.save(categoryRequest);
+    productService.save(productRequest, memberContext);
+  }
+
+  @AfterEach
+  void clearDB() {
+    databaseCleanup.execute();
+  }
+
+  @DisplayName("비회원인 경우 좋아요 API 를 호출하면 로그인 페이지로 Redirect 된다.")
+  @Test
+  void 비회원_상품_좋아요() throws Exception {
+    // when & then
+    mvc.perform(post("/api/likes/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection())
+        .andExpect(header().exists(HttpHeaders.LOCATION));
+  }
+
+  @DisplayName("존재하지 않는 상품 좋아요 API 호출 시 400 예외가 발생한다.")
+  @WithMockCustomUser(userId = 1, username = "username")
+  @Test
+  void 존재하지_않는_상품_좋아요() throws Exception {
+    // when & then
+    mvc.perform(post("/api/likes/2")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isBadRequest())
+
+        .andExpect(jsonPath("code").value(-1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.BAD_REQUEST.name()))
+        .andExpect(jsonPath("message").value(
+            ExceptionMessage.NOT_FOUND_PRODUCT.getErrorMessage()));
+  }
+
+  @DisplayName("회원인 경우, 좋아요를 누르지 않은 상품에 대해 좋아요 API 호출 시 해당 상품에 대한 좋아요가 생성된다.")
+  @WithMockCustomUser(userId = 1, username = "username")
+  @Test
+  void 회원_좋아요_눌리지_않은_상품_좋아요() throws Exception {
+    // when & then
+    mvc.perform(post("/api/likes/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isCreated())
+
+        .andExpect(jsonPath("code").value(1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.CREATED.name()))
+        .andExpect(jsonPath("message").value(
+            GlobalResponseMessage.SUCCESS_PRODUCT_LIKE.getSuccessMessage()));
+  }
+
+  @DisplayName("회원인 경우, 좋아요를 이미 누른 상품에 대해 좋아요 API 호출 시 또한 성공적으로 호출된다.")
+  @WithMockCustomUser(userId = 1, username = "username")
+  @Test
+  void 회원_이미_좋아요_눌린_상품_좋아요() throws Exception {
+    // given
+    MemberContext memberContext = (MemberContext) SecurityContextHolder.getContext()
+        .getAuthentication()
+        .getPrincipal();
+    likesService.like(1L, memberContext);
+
+    // when & then
+    mvc.perform(post("/api/likes/1")
+            .with(csrf())
+            .accept(accept))
+        .andDo(print())
+        .andExpect(status().isCreated());
+  }
+
+  /**
+   * private Method
+   */
+  private CreateProductRequest getInitProduct() {
+    Long categoryId = 1L;
+    String title = "Init Product Title";
+    String content = "Init Product Content";
+    int price = 10_000;
+
+    List<ProductImageRequest> imagesUrl = List.of(
+        ProductImageRequest.testConstructor("URL1"),
+        ProductImageRequest.testConstructor("URL2")
+    );
+
+    return CreateProductRequest.testConstructor(categoryId, title, content, price, imagesUrl);
+  }
+
+  private CreateCategoryRequest getInitCategory() {
+    String name = "Init Category Name";
+
+    return CreateCategoryRequest.testConstructor(name);
+  }
+}


### PR DESCRIPTION
### 🔧 Security Config 수정
- Security Config 설정에 의해 비회원이 상품 좋아요를 호출할 경우 /loginForm 으로 Redirect 되도록 /api/likes/** 경로 추가

---

### 💡LikesApiController 수정
- LikesController -> LikesApiController 로 클래스 네이밍 변경
- @RequestMapping 기본 경로 변경 및 produces 옵션 추가

---

### 💡 LikesService 수정
- Security Config 설정으로 비회원인 경우 로그인 페이지로 Redirect 되기 떄문에 like() 메서드에서 회원을 찾는 로직 삭제

---

### ✅ Likes Controller 통합 테스트 생성
1. 좋아요 생성
  - 비회원의 상품 좋아요 테스트 완료
  - 존재하지 않는 상품 좋아요 테스트 완료
  - 회원인 경우, 해당 상품에 처음 좋아요 테스트 완료
  - 회원인 경우, 해당 상품에 이미 좋아요를 눌렀던 경우 테스트 완료