### PR TITLE
Category 관련 수정사항 및 자잘한 수정 반영

### DIFF
--- a/src/main/java/com/market/carrot/category/controller/CategoryApiController.java
+++ b/src/main/java/com/market/carrot/category/controller/CategoryApiController.java
@@ -1,0 +1,38 @@
+package com.market.carrot.category.controller;
+
+import com.market.carrot.category.domain.dto.CreateCategoryRequest;
+import com.market.carrot.category.service.CategoryService;
+import com.market.carrot.global.GlobalResponseDto;
+import com.market.carrot.global.GlobalResponseMessage;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/category/", produces = MediaTypes.HAL_JSON_VALUE)
+@RestController
+public class CategoryApiController {
+
+  private final CategoryService categoryService;
+
+  @ResponseStatus(HttpStatus.CREATED)
+  @PostMapping
+  GlobalResponseDto save(@RequestBody CreateCategoryRequest createCategoryRequest,
+      @AuthenticationPrincipal MemberContext memberContext) {
+
+    categoryService.save(createCategoryRequest, memberContext);
+
+    return GlobalResponseDto.builder()
+        .code(1)
+        .httpStatus(HttpStatus.CREATED)
+        .message(GlobalResponseMessage.SUCCESS_POST_CATEGORY.getSuccessMessage())
+        .build();
+  }
+}

--- a/src/main/java/com/market/carrot/category/service/CategoryService.java
+++ b/src/main/java/com/market/carrot/category/service/CategoryService.java
@@ -1,8 +1,9 @@
 package com.market.carrot.category.service;
 
 import com.market.carrot.category.domain.dto.CreateCategoryRequest;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 
 public interface CategoryService {
 
-  void save(CreateCategoryRequest categoryRequest);
+  void save(CreateCategoryRequest categoryRequest, MemberContext memberContext);
 }

--- a/src/main/java/com/market/carrot/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/market/carrot/category/service/CategoryServiceImpl.java
@@ -3,8 +3,12 @@ package com.market.carrot.category.service;
 import com.market.carrot.category.domain.Category;
 import com.market.carrot.category.domain.CategoryRepository;
 import com.market.carrot.category.domain.dto.CreateCategoryRequest;
+import com.market.carrot.global.Exception.ExceptionMessage;
+import com.market.carrot.global.Exception.RoleException;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.login.domain.Role;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,9 +20,14 @@ public class CategoryServiceImpl implements CategoryService {
 
   @Transactional
   @Override
-  public void save(CreateCategoryRequest categoryRequest) {
+  public void save(CreateCategoryRequest categoryRequest, MemberContext memberContext) {
     String name = categoryRequest.getName();
     Category saveCategory = Category.createCategory(name);
+
+    Role role = memberContext.getMember().getRole();
+    if (role.getKey().equals("ROLE_USER")) {
+      throw new RoleException(ExceptionMessage.INCORRECT_ROLE, HttpStatus.UNAUTHORIZED);
+    }
 
     categoryRepository.save(saveCategory);
   }

--- a/src/main/java/com/market/carrot/global/Exception/ExceptionMessage.java
+++ b/src/main/java/com/market/carrot/global/Exception/ExceptionMessage.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionMessage {
 
+  INCORRECT_ROLE("권한이 없습니다."),
+
   BAD_CREDENTIALS("일치하지 않는 비밀번호입니다."),
 
   NOT_FOUND_PRODUCT("존재하지 않는 상품입니다."),

--- a/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
@@ -16,6 +16,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  @ExceptionHandler(RoleException.class)
+  public GlobalResponseDto incorrectRole(RoleException roleException) {
+    log.error("roleException 발생: {}", roleException.getMessage());
+
+    return GlobalResponseDto.builder()
+        .code(-1)
+        .httpStatus(HttpStatus.UNAUTHORIZED)
+        .message(roleException.getMessage())
+        .build();
+  }
+
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(AnotherMemberException.class)
   public GlobalResponseDto isNotMyProfile(AnotherMemberException anotherMemberException) {
@@ -64,7 +76,8 @@ public class GlobalExceptionHandler {
           .fieldMessage(fieldError.getDefaultMessage())
           .build();
 
-      ValidationExceptionFieldResponse response = new ValidationExceptionFieldResponse(validationExceptionField);
+      ValidationExceptionFieldResponse response = new ValidationExceptionFieldResponse(
+          validationExceptionField);
       responses.add(response);
     }
 

--- a/src/main/java/com/market/carrot/global/Exception/RoleException.java
+++ b/src/main/java/com/market/carrot/global/Exception/RoleException.java
@@ -1,0 +1,17 @@
+package com.market.carrot.global.Exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public class RoleException extends RuntimeException {
+
+  private final ExceptionMessage errorMessage;
+  private final HttpStatus httpStatus;
+
+  @Override
+  public String getMessage() {
+    return errorMessage.getErrorMessage();
+  }
+
+}

--- a/src/main/java/com/market/carrot/global/GlobalResponseMessage.java
+++ b/src/main/java/com/market/carrot/global/GlobalResponseMessage.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalResponseMessage {
 
-  SUCCESS_PRODUCT_LIKE("제품 좋아요 성공"),
+  SUCCESS_POST_CATEGORY("카테고리 등록 성공"),
+
+  SUCCESS_POST_PRODUCT_LIKE("제품 좋아요 성공"),
 
   SUCCESS_GET_MEMBER("프로필 조회 성공"),
 

--- a/src/main/java/com/market/carrot/likes/controller/LikesApiController.java
+++ b/src/main/java/com/market/carrot/likes/controller/LikesApiController.java
@@ -30,7 +30,7 @@ public class LikesApiController {
     return GlobalResponseDto.builder()
         .code(1)
         .httpStatus(HttpStatus.CREATED)
-        .message(GlobalResponseMessage.SUCCESS_PRODUCT_LIKE.getSuccessMessage())
+        .message(GlobalResponseMessage.SUCCESS_POST_PRODUCT_LIKE.getSuccessMessage())
         .build();
   }
 }

--- a/src/main/java/com/market/carrot/likes/controller/LikesApiController.java
+++ b/src/main/java/com/market/carrot/likes/controller/LikesApiController.java
@@ -22,10 +22,10 @@ public class LikesApiController {
   private final LikesService likesService;
 
   @ResponseStatus(HttpStatus.CREATED)
-  @PostMapping("{id}")
-  GlobalResponseDto like(@PathVariable Long id, @AuthenticationPrincipal MemberContext memberContext) {
+  @PostMapping("{productId}")
+  GlobalResponseDto like(@PathVariable Long productId, @AuthenticationPrincipal MemberContext memberContext) {
 
-    likesService.like(id, memberContext);
+    likesService.like(productId, memberContext);
 
     return GlobalResponseDto.builder()
         .code(1)

--- a/src/main/java/com/market/carrot/likes/service/LikesService.java
+++ b/src/main/java/com/market/carrot/likes/service/LikesService.java
@@ -4,5 +4,5 @@ import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 
 public interface LikesService {
 
-  void like(Long id, MemberContext memberContext);
+  void like(Long productId, MemberContext memberContext);
 }

--- a/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
+++ b/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
@@ -24,11 +24,11 @@ public class LikesServiceImpl implements LikesService {
 
   @Transactional
   @Override
-  public void like(Long id, MemberContext memberContext) {
-    Product findProduct = productRepository.findById(id)
+  public void like(Long productId, MemberContext memberContext) {
+    Product findProduct = productRepository.findById(productId)
         .orElseThrow(() -> new NotFoundEntityException(ExceptionMessage.NOT_FOUND_PRODUCT, HttpStatus.BAD_REQUEST));
 
-    Likes findLikes = likesRepository.findByUsernameAndProductId(memberContext.getUsername(), id);
+    Likes findLikes = likesRepository.findByUsernameAndProductId(memberContext.getUsername(), productId);
 
     // 자신이 좋아요를 이미 누른 제품인 경우 heartCount 를 하나 줄이고 Entity 를 DB 에서 삭제한다.
     if (findLikes != null) {

--- a/src/main/java/com/market/carrot/login/config/SecurityConfig.java
+++ b/src/main/java/com/market/carrot/login/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
         .antMatchers(HttpMethod.GET, "/api/user/**").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.DELETE, "/api/user/**").hasAnyRole("USER", "ADMIN")
 
+        .antMatchers(HttpMethod.POST, "/api/category/**").hasAnyRole("ADMIN")
+
         .antMatchers(HttpMethod.GET, "/api/product/**").permitAll()
         .antMatchers(HttpMethod.POST, "/api/product/**").hasAnyRole("USER", "ADMIN")
         .antMatchers(HttpMethod.DELETE, "/api/product/**").hasAnyRole("USER", "ADMIN")

--- a/src/test/java/com/market/carrot/config/WithMockCustomUser.java
+++ b/src/test/java/com/market/carrot/config/WithMockCustomUser.java
@@ -1,5 +1,6 @@
 package com.market.carrot.config;
 
+import com.market.carrot.login.domain.Role;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.springframework.security.test.context.support.WithSecurityContext;
@@ -11,4 +12,6 @@ public @interface WithMockCustomUser {
   long userId() default 1;
 
   String username() default "user";
+
+  Role role() default Role.USER;
 }

--- a/src/test/java/com/market/carrot/config/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/market/carrot/config/WithMockCustomUserSecurityContextFactory.java
@@ -21,7 +21,7 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
     roles.add(new SimpleGrantedAuthority("USER"));
 
     Member member = Member.testConstructor(
-        annotation.userId(), annotation.username(), "password", null, Role.USER
+        annotation.userId(), annotation.username(), "password", null, annotation.role()
     );
 
     MemberContext memberContext = new MemberContext(member);

--- a/src/test/java/com/market/carrot/integration/category/controller/CategoryApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/category/controller/CategoryApiControllerTest.java
@@ -1,0 +1,128 @@
+package com.market.carrot.integration.category.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.market.carrot.category.domain.dto.CreateCategoryRequest;
+import com.market.carrot.category.service.CategoryService;
+import com.market.carrot.config.DatabaseCleanup;
+import com.market.carrot.config.WithMockCustomUser;
+import com.market.carrot.global.Exception.ExceptionMessage;
+import com.market.carrot.global.GlobalResponseMessage;
+import com.market.carrot.login.config.customAuthentication.common.MemberContext;
+import com.market.carrot.login.domain.Member;
+import com.market.carrot.login.domain.Role;
+import com.market.carrot.login.service.LoginService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class CategoryApiControllerTest {
+
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+  @Autowired
+  private MockMvc mvc;
+
+  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+  @Autowired
+  private ObjectMapper mapper;
+
+  @Autowired
+  private DatabaseCleanup databaseCleanup;
+
+  @Autowired
+  private LoginService loginService;
+
+  private final String accept = "application/hal+json;charset=UTF-8";
+
+  @BeforeEach
+  void saveProduct() {
+    Member createMember = Member.testConstructor(
+        1L, "username", "password", "email", Role.ADMIN);
+    MemberContext memberContext = new MemberContext(createMember);
+
+    loginService.save(memberContext.getMember());
+  }
+
+  @AfterEach
+  void clearDB() {
+    databaseCleanup.execute();
+  }
+
+  @DisplayName("비회원인 경우, 카테고리 생성 API 를 호출한다면 로그인 페이지로 Redirect 된다.")
+  @Test
+  void 비회원_카테고리_생성() throws Exception {
+    // given
+    CreateCategoryRequest createCategoryRequest = CreateCategoryRequest.testConstructor(
+        "Category Name");
+
+    // when & then
+    mvc.perform(post("/api/category")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(accept)
+            .content(mapper.writeValueAsString(createCategoryRequest)))
+        .andDo(print())
+        .andExpect(status().is3xxRedirection())
+        .andExpect(header().exists(HttpHeaders.LOCATION));
+  }
+
+  @DisplayName("회원이지만 USER 권한인 경우, 카테고리 생성 API 를 호출한다면 401 예외가 발생한다.")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
+  @Test
+  void 회원_카테고리_생성() throws Exception {
+    // given
+    CreateCategoryRequest createCategoryRequest = CreateCategoryRequest.testConstructor(
+        "Category Name");
+
+    // when & then
+    mvc.perform(post("/api/category/")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(accept)
+            .content(mapper.writeValueAsString(createCategoryRequest)))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+
+        .andExpect(jsonPath("code").value(-1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.UNAUTHORIZED.name()))
+        .andExpect(jsonPath("message").value(ExceptionMessage.INCORRECT_ROLE.getErrorMessage()));
+  }
+
+  @DisplayName("회원이면서 ADMIN 권한인 경우, 카테고리 생성 API 를 호출하면 카테고리가 하나 생성된다.")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.ADMIN)
+  @Test
+  void 관리자_카테고리_생성() throws Exception {
+    // given
+    CreateCategoryRequest createCategoryRequest = CreateCategoryRequest.testConstructor(
+        "Category Name");
+
+    // when & then
+    mvc.perform(post("/api/category/")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(accept)
+            .content(mapper.writeValueAsString(createCategoryRequest)))
+        .andDo(print())
+        .andExpect(status().isCreated())
+
+        .andExpect(jsonPath("code").value(1))
+        .andExpect(jsonPath("httpStatus").value(HttpStatus.CREATED.name()))
+        .andExpect(jsonPath("message").value(GlobalResponseMessage.SUCCESS_POST_CATEGORY.getSuccessMessage()));
+  }
+}

--- a/src/test/java/com/market/carrot/integration/like/controller/LikesApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/like/controller/LikesApiControllerTest.java
@@ -67,14 +67,14 @@ public class LikesApiControllerTest {
   @BeforeEach
   void saveProduct() {
     Member createMember = Member.testConstructor(
-        1L, "username", "password", "email", Role.USER);
+        1L, "username", "password", "email", Role.ADMIN);
     MemberContext memberContext = new MemberContext(createMember);
 
     CreateProductRequest productRequest = getInitProduct();
     CreateCategoryRequest categoryRequest = getInitCategory();
 
     loginService.save(memberContext.getMember());
-    categoryService.save(categoryRequest);
+    categoryService.save(categoryRequest, memberContext);
     productService.save(productRequest, memberContext);
   }
 
@@ -96,7 +96,7 @@ public class LikesApiControllerTest {
   }
 
   @DisplayName("존재하지 않는 상품 좋아요 API 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 존재하지_않는_상품_좋아요() throws Exception {
     // when & then
@@ -113,7 +113,7 @@ public class LikesApiControllerTest {
   }
 
   @DisplayName("회원인 경우, 좋아요를 누르지 않은 상품에 대해 좋아요 API 호출 시 해당 상품에 대한 좋아요가 생성된다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_좋아요_눌리지_않은_상품_좋아요() throws Exception {
     // when & then
@@ -126,11 +126,11 @@ public class LikesApiControllerTest {
         .andExpect(jsonPath("code").value(1))
         .andExpect(jsonPath("httpStatus").value(HttpStatus.CREATED.name()))
         .andExpect(jsonPath("message").value(
-            GlobalResponseMessage.SUCCESS_PRODUCT_LIKE.getSuccessMessage()));
+            GlobalResponseMessage.SUCCESS_POST_PRODUCT_LIKE.getSuccessMessage()));
   }
 
   @DisplayName("회원인 경우, 좋아요를 이미 누른 상품에 대해 좋아요 API 호출 시 또한 성공적으로 호출된다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_이미_좋아요_눌린_상품_좋아요() throws Exception {
     // given

--- a/src/test/java/com/market/carrot/integration/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/member/controller/MemberApiControllerTest.java
@@ -75,7 +75,7 @@ public class MemberApiControllerTest {
   }
 
   @DisplayName("회원이면서 자신의 프로필을 조회한다면 self, update, delete link 모두 응답에 포함되어야한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_내_프로필_조회() throws Exception {
     // when & then
@@ -92,7 +92,7 @@ public class MemberApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신의 프로필을 조회하는게 아닌 경우 조회 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 회원_다른_회원의_프로필_조회() throws Exception {
     // when & then
@@ -104,7 +104,7 @@ public class MemberApiControllerTest {
   }
 
   @DisplayName("회원이라면 자신의 프로필을 삭제할 수 있다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_내_프로필_삭제() throws Exception {
     // when & then
@@ -121,7 +121,7 @@ public class MemberApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신의 프로필을 삭제하는게 아닌 경우 삭제 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 회원_다른_회원_프로필_삭제() throws Exception {
     // when & then

--- a/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/product/controller/ProductApiControllerTest.java
@@ -66,14 +66,14 @@ public class ProductApiControllerTest {
   @BeforeEach
   void saveProduct() {
     Member createMember = Member.testConstructor(
-        1L, "username", "password", "email", Role.USER);
+        1L, "username", "password", "email", Role.ADMIN);
     MemberContext memberContext = new MemberContext(createMember);
 
     CreateProductRequest productRequest = getInitProduct();
     CreateCategoryRequest categoryRequest = getInitCategory();
 
     loginService.save(memberContext.getMember());
-    categoryService.save(categoryRequest);
+    categoryService.save(categoryRequest, memberContext);
     productService.save(productRequest, memberContext);
   }
 
@@ -100,7 +100,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("CreateProductRequest 를 받아 상품을 등록할 수 있다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_상품_등록() throws Exception {
     CreateProductRequest createProductRequest = getCreateProductRequest();
@@ -122,7 +122,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("상품 등록 시 CreateProductRequest 에 이미지가 없다면 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 이미지_없이_상품_등록() throws Exception {
     // given
@@ -167,7 +167,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌 경우 self link 만 응답에 포함되어야한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 자신이_등록한_상품이_이닌경우_상품조회() throws Exception {
     // when & then
@@ -187,7 +187,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원이면서 자신이 등록한 상품인 경우 self, update, delete link 모두 응답에 포함되어야한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 자신이_등록한_상품조회() throws Exception {
     // when & then
@@ -232,7 +232,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원일 경우 content 내부 각 상품의 단일 상품 조회 link, 바깥쪽 links[] 에 상품 등록 link 가 응답에 포함되어야한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_모든_상품조회() throws Exception {
     // when & then
@@ -266,7 +266,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원일 경우 자신이 등록한 상품을 수정할 수 있다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_상품_수정() throws Exception {
     // given
@@ -288,7 +288,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌 경우 수정 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 자신이_등록한_상품이_아닌경우_상품수정_400() throws Exception {
     // given
@@ -321,7 +321,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원일 경우 자신이 등록한 상품을 삭제할 수 있다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_상품_삭제() throws Exception {
     // when & then
@@ -338,7 +338,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌 경우 삭제 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 자신이_등록한_상품이_아닌경우_상품삭제_400() throws Exception {
     // when & then
@@ -354,7 +354,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("존재하지 않는 상품 조회 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 존재하지_않는_상품_단일_조회() throws Exception {
     // when & then
@@ -370,7 +370,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("존재하지 않는 상품 수정 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 존재하지_않는_상품_수정() throws Exception {
     // given
@@ -391,7 +391,7 @@ public class ProductApiControllerTest {
   }
 
   @DisplayName("존재하지 않는 상품 삭제 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 존재하지_않는_상품_삭제() throws Exception {
     // when & then

--- a/src/test/java/com/market/carrot/integration/product/controller/ProductImageApiControllerTest.java
+++ b/src/test/java/com/market/carrot/integration/product/controller/ProductImageApiControllerTest.java
@@ -65,14 +65,14 @@ public class ProductImageApiControllerTest {
   @BeforeEach
   void saveProduct() {
     Member createMember = Member.testConstructor(
-        1L, "username", "password", "email", Role.USER);
+        1L, "username", "password", "email", Role.ADMIN);
     MemberContext memberContext = new MemberContext(createMember);
 
     CreateProductRequest productRequest = getInitProduct();
     CreateCategoryRequest categoryRequest = getInitCategory();
 
     loginService.save(memberContext.getMember());
-    categoryService.save(categoryRequest);
+    categoryService.save(categoryRequest, memberContext);
     productService.save(productRequest, memberContext);
   }
 
@@ -100,7 +100,7 @@ public class ProductImageApiControllerTest {
   }
 
   @DisplayName("회원이면서 자신이 등록한 상품인경우 이미지를 수정할 수 있다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_자신이_등록한_상품_이미지_수정() throws Exception {
     // given
@@ -123,7 +123,7 @@ public class ProductImageApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌경우 수정 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 회원_자신이_등록하지_않은_상품_이미지_수정() throws Exception {
     // given
@@ -158,7 +158,7 @@ public class ProductImageApiControllerTest {
   }
 
   @DisplayName("회원이면서 자신이 등록한 상품인경우 이미지를 삭제할 수 있다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 회원_자신이_등록한_상품_이미지_삭제() throws Exception {
     // when & then
@@ -175,7 +175,7 @@ public class ProductImageApiControllerTest {
   }
 
   @DisplayName("회원이지만 자신이 등록한 상품이 아닌경우 삭제 호출 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 2, username = "anotherUser")
+  @WithMockCustomUser(userId = 2, username = "anotherUser", role = Role.USER)
   @Test
   void 회원_자신이_등록하지_않은_상품_이미지_삭제() throws Exception {
     // when & then
@@ -191,7 +191,7 @@ public class ProductImageApiControllerTest {
   }
 
   @DisplayName("존재하지 않는 이미지 수정 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 존재하지_않는_상품_이미지_수정() throws Exception {
     // given
@@ -213,7 +213,7 @@ public class ProductImageApiControllerTest {
   }
 
   @DisplayName("존재하지 않는 이미지 삭제 시 400 예외가 발생한다.")
-  @WithMockCustomUser(userId = 1, username = "username")
+  @WithMockCustomUser(userId = 1, username = "username", role = Role.USER)
   @Test
   void 존재하지_않는_상품_이미지_삭제() throws Exception {
     // when & then


### PR DESCRIPTION
### 💡 Likes 에서 사용하는 매개변수 네이밍 변경
- id 라고 작성한 경우 Likes 의 id 가 아님에도 헷갈릴 요지가 있다고 판단.
- id 로 작성된 부분 -> productId 로 변경

---

### 🔧 Security Config 수정
- 비회원, USER 를 /loginForm 으로 Redirect 시키기 위해 /api/category/**/ 경로 추가

---

### ✨ RoleException 생성 및 핸들러 등록
- 카테고리 생성 시 권한이 맞지 않는다면 발생하는 RoleException 커스텀 예외 클래스 생성
- 핸들러에 작성 완료
- 알맞은 ExceptionMessage 작성 완료

---

### 💡 Category 관련 수정
1. CategoryApiController
    - 카테고리 생성을 위한 Controller 생성

2. CategoryService
    - 카테고리는 ADMIN 권한 유저만 등록할 수 있으므로, save() 매개변수로 MemberContext 추가

3. GlobalResponseMessage
    - 카테고리 등록에 사용할 알맞은 Success 메시지 생성
    - 제품 좋아요 성공 네이밍 수정

---

### 💡 @WithMockCustomUser 수정
- 통합 테스트 시 권한에 따라 테스트 할 로직이 생겨서, 기본적으로 USER 권한을 가지도록 하는게 아닌, 테스트 로직에서 어노테이션 활용 시 권한을 부여할 수 있도록 수정

---

### ✅ Category 통합 Controller 테스트 생성
1. 생성
    - 비회원인 경우 카테고리 생성
    - 회원이지만 USER 권한인 경우 카테고리 생성
    - 회원이면서 ADMIN 권한인 경우 카테고리 생성

---

### 💡 좋아요 호출 API 응답 message 변경
- GlobalResponseMessage 필드 변수 네이밍 변경으로 인한 수정사항
