### PR TITLE
ExceptionHandler 수정 및 좋아요 관련 동시성 이슈 해결

### DIFF
--- a/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/carrot/global/Exception/GlobalExceptionHandler.java
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(CustomException.class)
   public GlobalResponseDto incorrectRole(CustomException customException) {
     log.error("customException 발생: {}", customException.getMessage());
 
     return GlobalResponseDto.builder()
         .code(-1)
-        .httpStatus(HttpStatus.UNAUTHORIZED)
+        .httpStatus(HttpStatus.BAD_REQUEST)
         .message(customException.getMessage())
         .build();
   }

--- a/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
+++ b/src/main/java/com/market/carrot/likes/service/LikesServiceImpl.java
@@ -22,7 +22,7 @@ public class LikesServiceImpl implements LikesService {
   @Transactional
   @Override
   public void like(Long productId, MemberContext memberContext) {
-    Product findProduct = productRepository.findById(productId)
+    Product findProduct = productRepository.findByIdWithPessimisticLock(productId)
         .orElseThrow(() -> new CustomException(ExceptionMessage.NOT_FOUND_PRODUCT,
             HttpStatus.BAD_REQUEST));
 

--- a/src/main/java/com/market/carrot/member/domain/Member.java
+++ b/src/main/java/com/market/carrot/member/domain/Member.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Member extends BaseTime implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/market/carrot/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/market/carrot/member/service/MemberServiceImpl.java
@@ -4,12 +4,18 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import com.market.carrot.global.Exception.CustomException;
 import com.market.carrot.global.Exception.ResponseMessage.ExceptionMessage;
+import com.market.carrot.likes.domain.Likes;
+import com.market.carrot.likes.domain.LikesRepository;
 import com.market.carrot.login.config.customAuthentication.common.MemberContext;
 import com.market.carrot.member.controller.MemberApiController;
 import com.market.carrot.member.controller.dto.response.MemberResponse;
 import com.market.carrot.member.domain.Member;
 import com.market.carrot.member.domain.MemberRepository;
 import com.market.carrot.member.hateoas.MemberModel;
+import com.market.carrot.product.domain.Product;
+import com.market.carrot.product.domain.ProductRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.Link;
 import org.springframework.http.HttpStatus;
@@ -21,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
+  private final ProductRepository productRepository;
+  private final LikesRepository likesRepository;
 
   @Transactional(readOnly = true)
   @Override
@@ -63,6 +71,16 @@ public class MemberServiceImpl implements MemberService {
           HttpStatus.OK);
     }
 
+    List<Product> findProducts = productRepository.findAll().stream()
+        .filter(product -> product.getMember().getId().equals(findMember.getId()))
+        .collect(Collectors.toList());
+
+    List<Likes> findLikes = likesRepository.findAll().stream()
+        .filter(likes -> likes.getMember().getId().equals(findMember.getId()))
+        .collect(Collectors.toList());
+
+    productRepository.deleteAll(findProducts);
+    likesRepository.deleteAll(findLikes);
     memberRepository.delete(findMember);
   }
 }

--- a/src/main/java/com/market/carrot/product/domain/ProductRepository.java
+++ b/src/main/java/com/market/carrot/product/domain/ProductRepository.java
@@ -2,7 +2,9 @@ package com.market.carrot.product.domain;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,6 +13,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
   @Query("SELECT p FROM Product p JOIN FETCH p.member JOIN FETCH p.category")
   List<Product> readAll();
 
+  @Lock(value = LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT p FROM Product p JOIN FETCH p.member JOIN FETCH p.category WHERE p.id = :id")
-  Optional<Product> findById(@Param("id") Long id);
+  Optional<Product> findByIdWithPessimisticLock(@Param("id") Long id);
 }


### PR DESCRIPTION
## [💡 GlobalExceptionHandler 수정](https://github.com/juni8453/numble-carrot-market-challenge/commit/9fe7d884d7631dafc26de220ecbb8e88d364df80) 

### description
- UNAUTHORIZED -> BAD_REQUEST 로 수정

---
 
## [🚑 좋아요 증감 동시성 제어](https://github.com/juni8453/numble-carrot-market-challenge/commit/fdf1f6af4da2650d7e4a0fc65c82eaa548b78707) 

### description
- Pessimistic Lock 을 활용해 동시성 제어할 수 있도록 수정

---
 
## [💡 Member Entity 로직 추가](https://github.com/juni8453/numble-carrot-market-challenge/commit/8caeee39bb6a5255edafd599c4796674ba2c0cd6) 

### description
- 직렬화, 역직렬화시 직접 버전 관리를 위해 serialVersionUID = 1L 로 설정

---
 
## [💡 Member Service delete() 수정](https://github.com/juni8453/numble-carrot-market-challenge/commit/5cacd4e099327d00bd2afc57840496bca06dba76) 

### description
- Member 삭제 시 참조 무결성 원칙을 지키기 위해 member_id 값을 지닌 연관 Product, Likes 먼저 삭제하도록 로직 수정